### PR TITLE
feat(fake-image-detector): add checksum/ELA/EXIF checks with tests and schema updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,9 @@ Thumbs.db
 *.log
 
 *.sqlite3
+
+# GL-9: Fake / Staged Image Detector
+dummy/
+tools/fake_image_detector/local_samples/
+tools/fake_image_detector/models/
+tests/fixtures/dataset/

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,18 @@ uvicorn[standard]>=0.30.0
 pydantic-settings>=2.3.0
 pydantic>=2.8.0
 pydantic-ai>=0.0.14
-google-genai>=0.3
-numpy>=1.26
+google-genai>=1.0.0
+numpy>=1.26.0
 pyyaml>=6.0
 python-dotenv>=1.0
+
+# GL-9: Fake / Staged Image Detector
+pillow>=10.0.0
+pillow-heif>=0.18.0
+piexif>=1.1.3
+pytesseract>=0.3.10
+passporteye>=2.2.0
+google-cloud-aiplatform>=1.50.0
+google-cloud-vision>=3.7.0
+httpx>=0.27.0
+onnxruntime>=1.18.0

--- a/tests/unit/tools/fake_image_detector/test_build_pipeline.py
+++ b/tests/unit/tools/fake_image_detector/test_build_pipeline.py
@@ -1,0 +1,19 @@
+from tools.fake_image_detector.pipeline import FakeImageDetectorPipeline, build_pipeline
+
+
+def test_build_pipeline_returns_pipeline_instance():
+    pipeline = build_pipeline()
+    assert isinstance(pipeline, FakeImageDetectorPipeline)
+
+
+def test_build_pipeline_loads_at_least_one_check():
+    pipeline = build_pipeline()
+    assert len(pipeline._checks) > 0, (
+        "build_pipeline() produced no checks — likely a silent import failure in one or more check modules"
+    )
+
+
+def test_build_pipeline_check_ids_are_strings():
+    pipeline = build_pipeline()
+    for cfg, check in pipeline._checks:
+        assert isinstance(cfg.id, str) and cfg.id, f"check config has empty id: {cfg!r}"

--- a/tests/unit/tools/fake_image_detector/test_checksum_check.py
+++ b/tests/unit/tools/fake_image_detector/test_checksum_check.py
@@ -1,0 +1,124 @@
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tools.fake_image_detector.checks.checksum_check import ChecksumCheck
+
+
+def _make_schemas(checksum_value="iban"):
+    return {
+        "schemas": {
+            "bank_statement": {
+                "base": {
+                    "required_fields": [
+                        {
+                            "name": "IBAN",
+                            "regex": "[A-Z]{2}[0-9]{2}[A-Z0-9]{4,30}",
+                            "checksum": checksum_value,
+                        }
+                    ]
+                }
+            }
+        }
+    }
+
+
+def _make_ocr_mock(return_text: str):
+    """Return a context manager that injects mock pytesseract + PIL into sys.modules."""
+    mock_pytesseract = MagicMock()
+    mock_pytesseract.image_to_string.return_value = return_text
+
+    mock_image = MagicMock()
+    mock_pil = MagicMock()
+    mock_pil.Image.open.return_value = mock_image
+
+    return patch.dict(
+        sys.modules,
+        {
+            "pytesseract": mock_pytesseract,
+            "PIL": mock_pil,
+            "PIL.Image": mock_pil.Image,
+        },
+    )
+
+
+@pytest.fixture()
+def check():
+    return ChecksumCheck()
+
+
+class TestChecksumCheckSkip:
+    def test_skips_when_no_doc_type_in_context(self, check):
+        import asyncio
+        result = asyncio.run(check.run(b"", {}))
+        assert result.skipped is True
+
+    def test_skips_when_schema_not_found(self, check):
+        import asyncio
+        with patch(
+            "tools.fake_image_detector.checks.checksum_check._get_schemas",
+            return_value={"schemas": {}},
+        ):
+            result = asyncio.run(
+                check.run(b"", {"doc_type": "bank_statement"})
+            )
+        assert result.skipped is True
+
+    def test_skips_when_no_checksum_fields(self, check):
+        import asyncio
+        schemas = {
+            "schemas": {
+                "passport": {
+                    "base": {
+                        "required_fields": [
+                            {"name": "Document Number", "regex": "[A-Z0-9]{6,9}", "checksum": None}
+                        ]
+                    }
+                }
+            }
+        }
+        with patch(
+            "tools.fake_image_detector.checks.checksum_check._get_schemas",
+            return_value=schemas,
+        ):
+            result = asyncio.run(
+                check.run(b"", {"doc_type": "passport"})
+            )
+        assert result.skipped is True
+
+
+class TestChecksumCheckIban:
+    def _run(self, check, ocr_text, doc_type="bank_statement"):
+        import asyncio
+        with patch(
+            "tools.fake_image_detector.checks.checksum_check._get_schemas",
+            return_value=_make_schemas(),
+        ), _make_ocr_mock(ocr_text):
+            return asyncio.run(
+                check.run(b"fake", {"doc_type": doc_type})
+            )
+
+    def test_passes_valid_iban(self, check):
+        result = self._run(check, "IBAN: DE89370400440532013000")
+        assert result.passed is True
+        assert result.fake_score == 0.0
+        assert result.skipped is False
+        assert result.normalized_signals is not None
+        assert result.normalized_signals.category == "document_authenticity"
+        assert result.normalized_signals.indicators == ["CHECKSUM_VALID"]
+
+    def test_fails_invalid_iban(self, check):
+        result = self._run(check, "IBAN: DE89370400440532013001")
+        assert result.passed is False
+        assert result.fake_score == 1.0
+        assert "CHECKSUM_FAIL" in result.flags
+        assert "IBAN" in result.signals["failed_fields"]
+        assert result.normalized_signals is not None
+        assert result.normalized_signals.category == "document_authenticity"
+        assert result.normalized_signals.indicators == ["CHECKSUM_FAIL"]
+
+    def test_fails_when_iban_not_found_in_text(self, check):
+        result = self._run(check, "No IBAN present here")
+        assert result.passed is False
+        assert "IBAN" in result.signals["failed_fields"]

--- a/tests/unit/tools/fake_image_detector/test_checksums.py
+++ b/tests/unit/tools/fake_image_detector/test_checksums.py
@@ -1,0 +1,53 @@
+import pytest
+
+from tools.fake_image_detector.checks.checksums import validate_iban, validate_luhn, validate_mrz_digit
+
+
+class TestValidateLuhn:
+    def test_valid(self):
+        assert validate_luhn("4532015112830366") is True
+
+    def test_valid_amex(self):
+        assert validate_luhn("378282246310005") is True
+
+    def test_invalid(self):
+        assert validate_luhn("4532015112830367") is False
+
+    def test_empty(self):
+        assert validate_luhn("") is False
+
+    def test_non_digits_ignored(self):
+        assert validate_luhn("4532-0151-1283-0366") is True
+
+
+class TestValidateIban:
+    def test_valid_de(self):
+        assert validate_iban("DE89370400440532013000") is True
+
+    def test_valid_gb(self):
+        assert validate_iban("GB29NWBK60161331926819") is True
+
+    def test_invalid_checksum(self):
+        assert validate_iban("DE89370400440532013001") is False
+
+    def test_too_short(self):
+        assert validate_iban("DE89") is False
+
+    def test_spaces_stripped(self):
+        assert validate_iban("DE89 3704 0044 0532 0130 00") is True
+
+
+class TestValidateMrzDigit:
+    def test_valid(self):
+        # "L898902C3" — document number from ICAO sample, check digit 6
+        assert validate_mrz_digit("L898902C36") is True
+
+    def test_invalid(self):
+        assert validate_mrz_digit("L898902C37") is False
+
+    def test_filler_chars_skipped(self):
+        # '<' fillers treated as 0; ZE184226B< sums to 401 → check digit 1
+        assert validate_mrz_digit("ZE184226B<1") is True
+
+    def test_bad_character_returns_false(self):
+        assert validate_mrz_digit("????0") is False

--- a/tests/unit/tools/fake_image_detector/test_ela_check.py
+++ b/tests/unit/tools/fake_image_detector/test_ela_check.py
@@ -1,0 +1,30 @@
+import asyncio
+import io
+
+from PIL import Image
+
+from tools.fake_image_detector.checks.ela_check import ELACheck
+
+
+def run(coro):
+    return asyncio.run(coro)
+
+
+def _transparent_png_bytes(width: int = 64, height: int = 64) -> bytes:
+    img = Image.new("RGBA", (width, height), color=(0, 0, 0, 0))
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    return buf.getvalue()
+
+
+def test_transparent_png_is_processed_without_skip():
+    check = ELACheck()
+    result = run(check.run(_transparent_png_bytes(), {"input_type": "face"}))
+
+    assert result.skipped is False
+    assert result.error is None
+    assert "ela_mean" in result.signals
+    assert "ela_max" in result.signals
+    assert result.normalized_signals is not None
+    assert result.normalized_signals.category == "manipulation"
+    assert result.normalized_signals.manipulation_score == result.fake_score

--- a/tests/unit/tools/fake_image_detector/test_exif_check.py
+++ b/tests/unit/tools/fake_image_detector/test_exif_check.py
@@ -1,0 +1,68 @@
+import asyncio
+import io
+
+import piexif
+import pytest
+from PIL import Image
+
+from tools.fake_image_detector.checks.exif_check import EXIFCheck
+
+
+def run(coro):
+    return asyncio.run(coro)
+
+
+def _jpeg_bytes(width: int = 8, height: int = 8) -> bytes:
+    buf = io.BytesIO()
+    Image.new("RGB", (width, height), color=(128, 128, 128)).save(buf, format="JPEG")
+    return buf.getvalue()
+
+
+def _jpeg_with_exif(zeroth_ifd: dict) -> bytes:
+    exif_bytes = piexif.dump({"0th": zeroth_ifd, "Exif": {}, "GPS": {}, "Interop": {}, "1st": {}})
+    buf = io.BytesIO()
+    piexif.insert(exif_bytes, _jpeg_bytes(), buf)
+    return buf.getvalue()
+
+
+@pytest.fixture()
+def check():
+    return EXIFCheck()
+
+
+def test_non_jpeg_is_skipped(check):
+    buf = io.BytesIO()
+    Image.new("RGB", (8, 8)).save(buf, format="PNG")
+    result = run(check.run(buf.getvalue(), {}))
+    assert result.skipped is True
+
+
+def test_jpeg_without_exif_returns_low_confidence_pass(check):
+    result = run(check.run(_jpeg_bytes(), {}))
+    assert result.passed is True
+    assert result.skipped is False
+    assert "NO_EXIF_DATA" in result.flags
+    assert result.confidence == pytest.approx(0.2)
+
+
+def test_editing_software_fails(check):
+    result = run(check.run(_jpeg_with_exif({piexif.ImageIFD.Software: b"Adobe Photoshop 2024"}), {}))
+    assert result.passed is False
+    assert result.fake_score == 1.0
+    assert "EDITING_SOFTWARE_DETECTED" in result.flags
+    assert "photoshop" in result.signals["software"]
+
+
+def test_camera_exif_passes(check):
+    result = run(check.run(
+        _jpeg_with_exif({
+            piexif.ImageIFD.Make: b"NIKON CORPORATION",
+            piexif.ImageIFD.Model: b"NIKON D850",
+        }),
+        {},
+    ))
+    assert result.passed is True
+    assert result.fake_score == 0.0
+    assert result.skipped is False
+    assert result.signals.get("make") == "NIKON CORPORATION"
+    assert result.signals.get("model") == "NIKON D850"

--- a/tools/fake_image_detector/checks/base_check.py
+++ b/tools/fake_image_detector/checks/base_check.py
@@ -1,11 +1,14 @@
 from abc import ABC, abstractmethod
-from typing import TypedDict
+from typing import Literal, TypedDict
 
 from tools.fake_image_detector.models import CheckResult
 
 
 class CheckContext(TypedDict, total=False):
-    pass
+    input_type: Literal["document", "face", "unknown"]
+    doc_type: str
+    country: str
+    extracted_fields: dict[str, str]
 
 
 class BaseCheck(ABC):

--- a/tools/fake_image_detector/checks/checksum_check.py
+++ b/tools/fake_image_detector/checks/checksum_check.py
@@ -1,0 +1,120 @@
+import asyncio
+import io
+import re
+
+from tools.fake_image_detector.checks.base_check import BaseCheck, CheckContext
+from tools.fake_image_detector.checks.checksums import validate_iban, validate_luhn, validate_mrz_digit
+from tools.fake_image_detector.config_loader import load_document_schemas
+from tools.fake_image_detector.models import CheckResult, NormalizedSignals
+
+_ALGORITHMS = {
+    "mrz": validate_mrz_digit,
+    "luhn": validate_luhn,
+    "iban": validate_iban,
+}
+
+_SCHEMAS = None
+
+
+def _get_schemas() -> dict:
+    global _SCHEMAS
+    if _SCHEMAS is None:
+        _SCHEMAS = load_document_schemas()
+    return _SCHEMAS
+
+
+def _ocr_text(image_bytes: bytes) -> str | None:
+    try:
+        import pytesseract
+        from PIL import Image
+        return pytesseract.image_to_string(Image.open(io.BytesIO(image_bytes)))
+    except Exception:
+        return None
+
+
+class ChecksumCheck(BaseCheck):
+    check_id = "checksum"
+
+    async def run(self, image_bytes: bytes, context: CheckContext) -> CheckResult:
+        return await asyncio.to_thread(self._run_sync, image_bytes, context)
+
+    def _run_sync(self, image_bytes: bytes, context: CheckContext) -> CheckResult:
+        doc_type = context.get("doc_type")
+        if not doc_type:
+            return CheckResult(check=self.check_id, passed=True, confidence=0.0, skipped=True)
+
+        schemas = _get_schemas()
+        type_schemas = schemas.get("schemas", {}).get(doc_type)
+        if not type_schemas:
+            return CheckResult(check=self.check_id, passed=True, confidence=0.0, skipped=True)
+
+        country = context.get("country")
+        schema = type_schemas.get(country) or type_schemas.get("base")
+        if not schema:
+            return CheckResult(check=self.check_id, passed=True, confidence=0.0, skipped=True)
+
+        checksum_fields = [f for f in schema.get("required_fields", []) if f.get("checksum")]
+        if not checksum_fields:
+            return CheckResult(check=self.check_id, passed=True, confidence=0.0, skipped=True)
+
+        # Gemini-extracted fields (set by GeminiExtractCheck) are more reliable than OCR regex.
+        # Fall back to OCR only when extraction didn't run or didn't find the value.
+        extracted = context.get("extracted_fields", {})
+        ocr_text: str | None = None
+
+        failures = []
+        for field in checksum_fields:
+            algorithm = field["checksum"]
+            fn = _ALGORITHMS.get(algorithm)
+
+            # Prefer extracted value keyed by algorithm name (e.g. "iban" → extracted["iban"])
+            value = extracted.get(algorithm)
+
+            if value is None:
+                # Fall back to OCR regex
+                regex = field.get("regex")
+                if regex:
+                    if ocr_text is None:
+                        ocr_text = _ocr_text(image_bytes)
+                    if ocr_text:
+                        m = re.search(regex, ocr_text)
+                        value = m.group(0) if m else None
+
+            if value is None:
+                failures.append(field["name"])
+                continue
+
+            if fn and not fn(str(value)):
+                failures.append(field["name"])
+
+        if failures:
+            return CheckResult(
+                check=self.check_id,
+                passed=False,
+                fake_score=1.0,
+                confidence=0.9,
+                flags=["CHECKSUM_FAIL"],
+                signals={"failed_fields": failures},
+                normalized_signals=NormalizedSignals(
+                    category="document_authenticity",
+                    confidence=0.9,
+                    indicators=["CHECKSUM_FAIL"],
+                    document_type=doc_type,
+                    country_code=country,
+                    manipulation_score=1.0,
+                ),
+            )
+        return CheckResult(
+            check=self.check_id,
+            passed=True,
+            fake_score=0.0,
+            confidence=0.9,
+            normalized_signals=NormalizedSignals(
+                category="document_authenticity",
+                confidence=0.9,
+                indicators=["CHECKSUM_VALID"],
+                document_type=doc_type,
+                country_code=country,
+                manipulation_score=0.0,
+            ),
+        )

--- a/tools/fake_image_detector/checks/checksums.py
+++ b/tools/fake_image_detector/checks/checksums.py
@@ -1,0 +1,42 @@
+def validate_mrz_digit(value: str) -> bool:
+    """ICAO Doc 9303 weighted 7/3/1 mod-10 check digit."""
+    weights = [7, 3, 1]
+    chars = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+    try:
+        total = sum(
+            chars.index(c) * weights[i % 3]
+            for i, c in enumerate(value[:-1])
+            if c != "<"
+        )
+    except ValueError:
+        return False
+    try:
+        return (total % 10) == int(value[-1])
+    except (ValueError, IndexError):
+        return False
+
+
+def validate_luhn(value: str) -> bool:
+    digits = [int(c) for c in value if c.isdigit()]
+    if not digits:
+        return False
+    total = 0
+    for i, d in enumerate(reversed(digits)):
+        if i % 2 == 1:
+            d *= 2
+            if d > 9:
+                d -= 9
+        total += d
+    return total % 10 == 0
+
+
+def validate_iban(value: str) -> bool:
+    iban = value.replace(" ", "").upper()
+    if len(iban) < 5:
+        return False
+    rearranged = iban[4:] + iban[:4]
+    try:
+        numeric = "".join(str(ord(c) - 55) if c.isalpha() else c for c in rearranged)
+        return int(numeric) % 97 == 1
+    except ValueError:
+        return False

--- a/tools/fake_image_detector/checks/ela_check.py
+++ b/tools/fake_image_detector/checks/ela_check.py
@@ -1,0 +1,78 @@
+import asyncio
+import io
+
+import numpy as np
+from PIL import Image, ImageChops, UnidentifiedImageError
+
+from tools.fake_image_detector.checks.base_check import BaseCheck, CheckContext
+from tools.fake_image_detector.models import CheckResult, NormalizedSignals
+
+_DEFAULT_THRESHOLD = 4.0
+_RESAVE_QUALITY = 95
+
+
+class ELACheck(BaseCheck):
+    check_id = "ela"
+
+    def __init__(self, params: dict | None = None) -> None:
+        p = params or {}
+        self._threshold = float(p.get("threshold", _DEFAULT_THRESHOLD))
+        self._document_threshold = float(p.get("document_threshold", self._threshold))
+
+    async def run(self, image_bytes: bytes, context: CheckContext) -> CheckResult:
+        return await asyncio.to_thread(self._run_sync, image_bytes, context)
+
+    def _run_sync(self, image_bytes: bytes, context: CheckContext) -> CheckResult:
+        threshold = self._document_threshold if context.get("input_type") == "document" else self._threshold
+
+        try:
+            source = Image.open(io.BytesIO(image_bytes))
+            if "A" in source.getbands():
+                alpha = source.convert("RGBA")
+                original = Image.new("RGB", alpha.size, (255, 255, 255))
+                original.paste(alpha, mask=alpha.getchannel("A"))
+            else:
+                original = source.convert("RGB")
+        except (UnidentifiedImageError, ValueError, OSError) as e:
+            return CheckResult(check=self.check_id, passed=True, confidence=0.0, skipped=True, error=str(e))
+
+        buf = io.BytesIO()
+        original.save(buf, format="JPEG", quality=_RESAVE_QUALITY)
+        buf.seek(0)
+        resaved = Image.open(buf).convert("RGB")
+
+        diff = ImageChops.difference(original, resaved)
+        amplified = diff.point(lambda px: min(px * 20, 255))
+
+        ela_mean = float(np.array(amplified).mean())
+        ela_max = int(np.array(amplified).max())
+
+        if ela_mean > threshold:
+            return CheckResult(
+                check=self.check_id,
+                passed=False,
+                fake_score=1.0,
+                confidence=1.0,
+                flags=["HIGH_ELA_SCORE"],
+                signals={"ela_mean": round(ela_mean, 3), "ela_max": ela_max},
+                normalized_signals=NormalizedSignals(
+                    category="manipulation",
+                    confidence=1.0,
+                    indicators=["HIGH_ELA_SCORE"],
+                    manipulation_score=1.0,
+                ),
+            )
+
+        return CheckResult(
+            check=self.check_id,
+            passed=True,
+            fake_score=0.0,
+            confidence=1.0,
+            signals={"ela_mean": round(ela_mean, 3), "ela_max": ela_max},
+            normalized_signals=NormalizedSignals(
+                category="manipulation",
+                confidence=1.0,
+                indicators=["CLEAN"],
+                manipulation_score=0.0,
+            ),
+        )

--- a/tools/fake_image_detector/checks/exif_check.py
+++ b/tools/fake_image_detector/checks/exif_check.py
@@ -1,0 +1,62 @@
+import asyncio
+import re
+
+import piexif
+
+from tools.fake_image_detector.checks.base_check import BaseCheck, CheckContext
+from tools.fake_image_detector.models import CheckResult
+
+EDITING_SOFTWARE_PATTERN = re.compile(r"\b(?:photoshop|gimp|lightroom|affinity|capture one|darktable)\b")
+
+
+class EXIFCheck(BaseCheck):
+    check_id = "exif"
+
+    def __init__(self, params: dict | None = None) -> None:
+        p = params or {}
+        self._no_exif_confidence = float(p.get("no_exif_confidence", 0.2))
+
+    async def run(self, image_bytes: bytes, context: CheckContext) -> CheckResult:
+        return await asyncio.to_thread(self._run_sync, image_bytes)
+
+    def _run_sync(self, image_bytes: bytes) -> CheckResult:
+        try:
+            exif_data = piexif.load(image_bytes)
+        except (piexif.InvalidImageDataError, ValueError):
+            # ValueError covers PNGs and other non-JPEG formats piexif can't parse
+            return CheckResult(check=self.check_id, passed=True, confidence=0.0, skipped=True)
+
+        zeroth = exif_data.get("0th", {})
+        software_raw = zeroth.get(piexif.ImageIFD.Software)
+
+        if not zeroth and not exif_data.get("Exif"):
+            return CheckResult(
+                check=self.check_id,
+                passed=True,
+                fake_score=0.0,
+                confidence=self._no_exif_confidence,
+                flags=["NO_EXIF_DATA"],
+            )
+
+        if software_raw:
+            software = software_raw.decode("utf-8", errors="ignore").strip().lower()
+            if EDITING_SOFTWARE_PATTERN.search(software):
+                return CheckResult(
+                    check=self.check_id,
+                    passed=False,
+                    fake_score=1.0,
+                    confidence=1.0,
+                    flags=["EDITING_SOFTWARE_DETECTED"],
+                    signals={"software": software},
+                )
+
+        make = zeroth.get(piexif.ImageIFD.Make, b"").decode("utf-8", errors="ignore").strip()
+        model = zeroth.get(piexif.ImageIFD.Model, b"").decode("utf-8", errors="ignore").strip()
+
+        return CheckResult(
+            check=self.check_id,
+            passed=True,
+            fake_score=0.0,
+            confidence=1.0,
+            signals={"make": make or None, "model": model or None},
+        )

--- a/tools/fake_image_detector/config/document_schemas.yaml
+++ b/tools/fake_image_detector/config/document_schemas.yaml
@@ -1,0 +1,157 @@
+# Document type detection keywords used by the OCR check.
+# The check scans extracted text for these keywords to classify the document type.
+# If keywords are found but the type is not listed here, the check flags UNRECOGNIZED_DOCUMENT_TYPE.
+# If no keywords are found at all, the check is skipped (image is not a document).
+
+detection_keywords:
+  passport:
+    - "passport"
+    - "reisepass"
+    - "passeport"
+    - "pasaporte"
+  national_id:
+    - "identity card"
+    - "national id"
+    - "personalausweis"
+    - "carte nationale"
+    - "cedula"
+  birth_certificate:
+    - "birth certificate"
+    - "certificate of birth"
+    - "geburtsurkunde"
+    - "acte de naissance"
+  death_certificate:
+    - "death certificate"
+    - "certificate of death"
+    - "sterbeurkunde"
+  driving_license:
+    - "driving licence"
+    - "driver's license"
+    - "führerschein"
+    - "permis de conduire"
+  bank_statement:
+    - "bank statement"
+    - "account statement"
+    - "IBAN"
+
+# Field validation schemas per document type.
+# Structure: doc_type -> country (or "base") -> required_fields[]
+# "base" is used when the country is unknown or not listed.
+# Each field has a "name" (case-insensitive substring match), optional "regex",
+# and optional "checksum" algorithm key ("mrz", "luhn", "iban", or null).
+
+schemas:
+  passport:
+    base:
+      required_fields:
+        - name: "Document Number"
+          regex: "[A-Z0-9]{6,9}"
+          checksum: null
+        - name: "Date of Birth"
+          regex: "\\d{2,4}[.\\-/]\\d{2}[.\\-/]\\d{2,4}"
+          checksum: null
+        - name: "Expiry"
+          regex: "\\d{2,4}[.\\-/]\\d{2}[.\\-/]\\d{2,4}"
+          checksum: null
+    DE:
+      required_fields:
+        - name: "Pass-Nr"
+          regex: "[A-Z0-9]{9}"
+          checksum: null
+        - name: "Geburtsdatum"
+          regex: "\\d{2}[.\\-/]\\d{2}[.\\-/]\\d{2,4}"
+          checksum: null
+        - name: "Ablaufdatum"
+          regex: "\\d{2}[.\\-/]\\d{2}[.\\-/]\\d{2,4}"
+          checksum: null
+    KE:
+      required_fields:
+        - name: "Republic of Kenya"
+          regex: null
+          checksum: null
+        - name: "Passport No"
+          regex: "[A-Z]{1}[0-9]{7}"
+          checksum: null
+    NG:
+      required_fields:
+        - name: "Federal Republic of Nigeria"
+          regex: null
+          checksum: null
+        - name: "Passport No"
+          regex: "[A-Z]{1}[0-9]{8}"
+          checksum: null
+
+  national_id:
+    base:
+      required_fields:
+        - name: "Identity"
+          regex: null
+          checksum: null
+        - name: "Date of Birth"
+          regex: "\\d{2,4}[.\\-/]\\d{2}[.\\-/]\\d{2,4}"
+          checksum: null
+    DE:
+      required_fields:
+        - name: "Personalausweis"
+          regex: null
+          checksum: null
+        - name: "Geburtsdatum"
+          regex: null
+          checksum: null
+    KE:
+      required_fields:
+        - name: "National Identity Card"
+          regex: null
+          checksum: null
+        - name: "ID No"
+          regex: "[0-9]{7,8}"
+          checksum: null
+
+  birth_certificate:
+    base:
+      required_fields:
+        - name: "Name"
+          regex: null
+          checksum: null
+        - name: "Date of Birth"
+          regex: "\\d{2,4}[.\\-/]\\d{2}[.\\-/]\\d{2,4}"
+          checksum: null
+        - name: "Place of Birth"
+          regex: null
+          checksum: null
+
+  death_certificate:
+    base:
+      required_fields:
+        - name: "Name"
+          regex: null
+          checksum: null
+        - name: "Date of Death"
+          regex: "\\d{2,4}[.\\-/]\\d{2}[.\\-/]\\d{2,4}"
+          checksum: null
+        - name: "Place of Death"
+          regex: null
+          checksum: null
+
+  driving_license:
+    base:
+      required_fields:
+        - name: "Licence No"
+          regex: "[A-Z0-9]{5,15}"
+          checksum: null
+        - name: "Date of Birth"
+          regex: "\\d{2,4}[.\\-/]\\d{2}[.\\-/]\\d{2,4}"
+          checksum: null
+        - name: "Expiry"
+          regex: "\\d{2,4}[.\\-/]\\d{2}[.\\-/]\\d{2,4}"
+          checksum: null
+
+  bank_statement:
+    base:
+      required_fields:
+        - name: "IBAN"
+          regex: "[A-Z]{2}[0-9]{2}[A-Z0-9]{4,30}"
+          checksum: "iban"
+        - name: "Account"
+          regex: null
+          checksum: null


### PR DESCRIPTION
## Summary

- Add EXIF, ELA, and Checksum validation checks (local checks — no external API dependencies)
- Add checksum utility module (`checksums.py`) with Luhn, IBAN mod-97, and MRZ ICAO 9303 implementations
- Populate `CheckContext` in `base_check.py` with typed fields (`input_type`, `doc_type`, `country`, `extracted_fields`)
- Add `document_schemas.yaml` — field validation schemas per document type and country used by `ChecksumCheck`
- Add `test_build_pipeline.py` smoke test: guards against silent import failures in `build_pipeline()`
- Update `requirements.txt` with new dependencies (pillow, piexif, pytesseract, passporteye, etc.)
- Update `.gitignore` for local samples, models, and dataset fixtures

## Design note

`ChecksumCheck` first looks for Gemini-extracted fields in `context["extracted_fields"]` (populated by `GeminiExtractCheck` when it runs). If absent, it falls back to pytesseract OCR regex on the raw image. This means checksum validation works in both the full pipeline (PR 3) and in isolation.

## Test plan

- [ ] `pytest -q tests/unit/tools/fake_image_detector` — 77 passed
- [ ] EXIF: non-JPEG skipped, no-EXIF low-confidence pass, editing software flagged, camera EXIF passes
- [ ] ELA: transparent PNG processed without skip
- [ ] Checksum: skip cases (no doc_type, unknown schema, no checksum fields), valid IBAN passes, invalid IBAN fails, missing IBAN fails
- [ ] Checksums: Luhn, IBAN, MRZ digit algorithms verified against known-good values
- [ ] Build pipeline smoke test: `build_pipeline()` loads at least one check with the real config