### PR TITLE
feat(gl-9): fake/staged image detector — external API checks and pipeline orchestration

### DIFF
--- a/tests/unit/tools/fake_image_detector/test_cnn_deepfake_check.py
+++ b/tests/unit/tools/fake_image_detector/test_cnn_deepfake_check.py
@@ -1,0 +1,97 @@
+import asyncio
+import io
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+from PIL import Image
+
+from tools.fake_image_detector.checks.cnn_deepfake_check import CNNDeepfakeCheck
+
+
+def _jpeg_bytes(width=64, height=64) -> bytes:
+    img = Image.new("RGB", (width, height), color=(120, 80, 60))
+    buf = io.BytesIO()
+    img.save(buf, format="JPEG")
+    return buf.getvalue()
+
+
+def _mock_session(logits: list[float]):
+    session = MagicMock()
+    session.get_inputs.return_value = [MagicMock(name="pixel_values")]
+    session.get_outputs.return_value = [MagicMock(name="logits")]
+    session.run.return_value = [np.array([logits], dtype=np.float32)]
+    return session
+
+
+def run(coro):
+    return asyncio.run(coro)
+
+
+class TestCNNDeepfakeCheck:
+    def test_skips_when_model_not_present(self, tmp_path):
+        check = CNNDeepfakeCheck(model_path=tmp_path / "nonexistent.onnx")
+        result = run(check.run(_jpeg_bytes(), {}))
+        assert result.skipped is True
+        assert result.passed is True
+        assert result.confidence == 0.0
+
+    def test_detects_fake_image(self, tmp_path):
+        model_path = tmp_path / "model.onnx"
+        model_path.touch()
+        check = CNNDeepfakeCheck(model_path=model_path)
+        # logits: [high_fake, low_real] → p_fake > 0.5 after softmax
+        check._session = _mock_session([5.0, -5.0])
+        result = run(check.run(_jpeg_bytes(), {}))
+        assert result.passed is False
+        assert "CNN_DEEPFAKE_DETECTED" in result.flags
+        assert result.signals["p_fake"] > 0.5
+        assert result.normalized_signals is not None
+        assert result.normalized_signals.category == "synthetic"
+        assert result.normalized_signals.synthetic_score == result.signals["p_fake"]
+
+    def test_passes_real_image(self, tmp_path):
+        model_path = tmp_path / "model.onnx"
+        model_path.touch()
+        check = CNNDeepfakeCheck(model_path=model_path)
+        # logits: [low_fake, high_real] → p_fake < 0.5
+        check._session = _mock_session([-5.0, 5.0])
+        result = run(check.run(_jpeg_bytes(), {}))
+        assert result.passed is True
+        assert result.flags == []
+        assert result.signals["p_real"] > 0.5
+
+    def test_skips_on_corrupt_image(self, tmp_path):
+        model_path = tmp_path / "model.onnx"
+        model_path.touch()
+        check = CNNDeepfakeCheck(model_path=model_path)
+        check._session = _mock_session([-5.0, 5.0])
+        result = run(check.run(b"not_an_image", {}))
+        assert result.skipped is True
+        assert result.error is not None
+
+    def test_skips_on_inference_error(self, tmp_path):
+        model_path = tmp_path / "model.onnx"
+        model_path.touch()
+        check = CNNDeepfakeCheck(model_path=model_path)
+        session = MagicMock()
+        session.get_inputs.return_value = [MagicMock(name="pixel_values")]
+        session.get_outputs.return_value = [MagicMock(name="logits")]
+        session.run.side_effect = RuntimeError("ONNX runtime error")
+        check._session = session
+        result = run(check.run(_jpeg_bytes(), {}))
+        assert result.skipped is True
+        assert "ONNX runtime error" in result.error
+
+    def test_confidence_reflects_p_fake(self, tmp_path):
+        model_path = tmp_path / "model.onnx"
+        model_path.touch()
+        check = CNNDeepfakeCheck(model_path=model_path)
+        check._session = _mock_session([3.0, -3.0])
+        result = run(check.run(_jpeg_bytes(), {}))
+        assert result.passed is False
+        assert result.confidence == result.signals["p_fake"]
+
+    def test_check_id(self):
+        assert CNNDeepfakeCheck.check_id == "cnn_deepfake"

--- a/tests/unit/tools/fake_image_detector/test_gemini_extract_check.py
+++ b/tests/unit/tools/fake_image_detector/test_gemini_extract_check.py
@@ -1,0 +1,181 @@
+import asyncio
+import io
+import json
+import os
+import sys
+from unittest.mock import MagicMock
+
+from PIL import Image
+
+from tools.fake_image_detector.checks.gemini_extract_check import GeminiExtractCheck
+
+
+def run(coro):
+    return asyncio.run(coro)
+
+
+def _jpeg_bytes(width=64, height=64) -> bytes:
+    img = Image.new("RGB", (width, height), color=(100, 150, 200))
+    buf = io.BytesIO()
+    img.save(buf, format="JPEG")
+    return buf.getvalue()
+
+
+def _install_mock_genai(response_text: str) -> MagicMock:
+    mock_response = MagicMock()
+    mock_response.text = response_text
+
+    mock_client = MagicMock()
+    mock_client.models.generate_content.return_value = mock_response
+
+    mock_genai = MagicMock()
+    mock_genai.Client.return_value = mock_client
+
+    sys.modules["google.genai"] = mock_genai
+    sys.modules["google.genai.types"] = MagicMock()
+    return mock_client
+
+
+def _remove_mock_genai() -> None:
+    sys.modules.pop("google.genai", None)
+    sys.modules.pop("google.genai.types", None)
+
+
+class TestGeminiExtractCheckSkip:
+    def test_check_id(self):
+        assert GeminiExtractCheck.check_id == "gemini_extract"
+
+    def test_skips_when_no_doc_type(self):
+        result = run(GeminiExtractCheck(project="test").run(_jpeg_bytes(), {}))
+        assert result.skipped is True
+        assert result.passed is True
+        assert result.confidence == 0.0
+
+    def test_skips_when_doc_type_has_no_field_list(self):
+        result = run(GeminiExtractCheck(project="test").run(_jpeg_bytes(), {"doc_type": "unknown_type"}))
+        assert result.skipped is True
+
+    def test_skips_when_project_not_set(self):
+        env_backup = os.environ.pop("GOOGLE_CLOUD_PROJECT", None)
+        sys.modules["google.genai"] = MagicMock()
+        sys.modules["google.genai.types"] = MagicMock()
+        try:
+            result = run(GeminiExtractCheck(project=None).run(_jpeg_bytes(), {"doc_type": "passport"}))
+        finally:
+            _remove_mock_genai()
+            if env_backup is not None:
+                os.environ["GOOGLE_CLOUD_PROJECT"] = env_backup
+        assert result.skipped is True
+        assert "GOOGLE_CLOUD_PROJECT" in result.error
+
+    def test_skips_on_api_error(self):
+        mock_client = MagicMock()
+        mock_client.models.generate_content.side_effect = RuntimeError("quota exceeded")
+        mock_genai = MagicMock()
+        mock_genai.Client.return_value = mock_client
+        sys.modules["google.genai"] = mock_genai
+        sys.modules["google.genai.types"] = MagicMock()
+        try:
+            result = run(GeminiExtractCheck(project="test").run(_jpeg_bytes(), {"doc_type": "passport"}))
+        finally:
+            _remove_mock_genai()
+        assert result.skipped is True
+        assert "quota exceeded" in result.error
+
+    def test_skips_on_json_parse_error(self):
+        _install_mock_genai("Sorry, I cannot extract fields from this image.")
+        try:
+            result = run(GeminiExtractCheck(project="test").run(_jpeg_bytes(), {"doc_type": "passport"}))
+        finally:
+            _remove_mock_genai()
+        assert result.skipped is True
+        assert "JSON parse error" in result.error
+
+
+class TestGeminiExtractCheckExtraction:
+    def test_extracts_passport_fields_and_stores_in_context(self):
+        payload = json.dumps({
+            "full_name": "Max Mustermann",
+            "document_number": "C01X00T47",
+            "date_of_birth": "1985-03-15",
+            "expiry_date": "2030-03-14",
+            "nationality": "DEU",
+        })
+        _install_mock_genai(payload)
+        context = {"doc_type": "passport"}
+        try:
+            result = run(GeminiExtractCheck(project="test").run(_jpeg_bytes(), context))
+        finally:
+            _remove_mock_genai()
+
+        assert result.skipped is True
+        assert result.passed is True
+        extracted = context.get("extracted_fields", {})
+        assert extracted["full_name"] == "Max Mustermann"
+        assert extracted["document_number"] == "C01X00T47"
+        assert result.signals["extracted"]["date_of_birth"] == "1985-03-15"
+
+    def test_null_values_excluded_from_extracted_fields(self):
+        payload = json.dumps({
+            "full_name": "Anna Schmidt",
+            "document_number": None,
+            "date_of_birth": "1990-07-22",
+            "expiry_date": None,
+            "nationality": "DEU",
+        })
+        _install_mock_genai(payload)
+        context = {"doc_type": "passport"}
+        try:
+            run(GeminiExtractCheck(project="test").run(_jpeg_bytes(), context))
+        finally:
+            _remove_mock_genai()
+
+        extracted = context.get("extracted_fields", {})
+        assert "document_number" not in extracted
+        assert "expiry_date" not in extracted
+        assert extracted["full_name"] == "Anna Schmidt"
+
+    def test_extracts_bank_statement_iban(self):
+        payload = json.dumps({
+            "account_holder": "Max Mustermann",
+            "iban": "DE89370400440532013000",
+            "account_number": "0532013000",
+        })
+        _install_mock_genai(payload)
+        context = {"doc_type": "bank_statement"}
+        try:
+            run(GeminiExtractCheck(project="test").run(_jpeg_bytes(), context))
+        finally:
+            _remove_mock_genai()
+
+        assert context["extracted_fields"]["iban"] == "DE89370400440532013000"
+
+    def test_extracts_birth_certificate_fields(self):
+        payload = json.dumps({
+            "full_name": "Emma Müller",
+            "date_of_birth": "2000-01-10",
+            "place_of_birth": "Berlin",
+            "signed_by": "Standesamt Berlin",
+        })
+        _install_mock_genai(payload)
+        context = {"doc_type": "birth_certificate"}
+        try:
+            result = run(GeminiExtractCheck(project="test").run(_jpeg_bytes(), context))
+        finally:
+            _remove_mock_genai()
+
+        extracted = context.get("extracted_fields", {})
+        assert extracted["signed_by"] == "Standesamt Berlin"
+        assert result.signals["doc_type"] == "birth_certificate"
+
+    def test_markdown_wrapped_json_is_parsed(self):
+        payload = json.dumps({"full_name": "Test User", "date_of_death": "2024-05-01", "place_of_death": "Hamburg", "signed_by": "Amt"})
+        _install_mock_genai(f"```json\n{payload}\n```")
+        context = {"doc_type": "death_certificate"}
+        try:
+            result = run(GeminiExtractCheck(project="test").run(_jpeg_bytes(), context))
+        finally:
+            _remove_mock_genai()
+
+        assert result.skipped is True
+        assert context["extracted_fields"]["full_name"] == "Test User"

--- a/tests/unit/tools/fake_image_detector/test_gemini_vision_check.py
+++ b/tests/unit/tools/fake_image_detector/test_gemini_vision_check.py
@@ -1,0 +1,225 @@
+import asyncio
+import io
+import json
+import os
+import sys
+from unittest.mock import MagicMock
+
+from PIL import Image
+
+from tools.fake_image_detector.checks.gemini_vision_check import GeminiVisionCheck
+
+
+def run(coro):
+    return asyncio.run(coro)
+
+
+def _jpeg_bytes(width=64, height=64) -> bytes:
+    img = Image.new("RGB", (width, height), color=(100, 150, 200))
+    buf = io.BytesIO()
+    img.save(buf, format="JPEG")
+    return buf.getvalue()
+
+
+def _install_mock_genai(response_text: str) -> MagicMock:
+    mock_response = MagicMock()
+    mock_response.text = response_text
+
+    mock_client = MagicMock()
+    mock_client.models.generate_content.return_value = mock_response
+
+    mock_genai = MagicMock()
+    mock_genai.Client.return_value = mock_client
+
+    sys.modules["google.genai"] = mock_genai
+    sys.modules["google.genai.types"] = MagicMock()
+    return mock_client
+
+
+def _remove_mock_genai() -> None:
+    sys.modules.pop("google.genai", None)
+    sys.modules.pop("google.genai.types", None)
+
+
+class TestGeminiVisionCheck:
+    def test_check_id(self):
+        assert GeminiVisionCheck.check_id == "gemini_vision"
+
+    def test_detects_synthetic_image(self):
+        _install_mock_genai(json.dumps({
+            "is_deceptive": True,
+            "fake_likelihood": 0.87,
+            "confidence": 0.87,
+            "signals": ["unnatural skin texture", "bilateral symmetry"],
+            "flags": ["GAN_ARTIFACTS", "UNNATURAL_TEXTURE"],
+        }))
+        try:
+            result = run(GeminiVisionCheck(project="test-project").run(_jpeg_bytes(), {}))
+        finally:
+            _remove_mock_genai()
+
+        assert result.passed is False
+        assert result.skipped is False
+        assert result.fake_score == 0.87
+        assert result.confidence == 0.87
+        assert "GAN_ARTIFACTS" in result.flags
+        assert result.signals["is_deceptive"] is True
+        assert result.normalized_signals is not None
+        assert result.normalized_signals.category == "synthetic"
+        assert result.normalized_signals.synthetic_score == 0.87
+
+    def test_passes_real_image(self):
+        _install_mock_genai(json.dumps({
+            "is_deceptive": False,
+            "fake_likelihood": 0.05,
+            "confidence": 0.9,
+            "signals": [],
+            "flags": ["CLEAN"],
+        }))
+        try:
+            result = run(GeminiVisionCheck(project="test-project").run(_jpeg_bytes(), {}))
+        finally:
+            _remove_mock_genai()
+
+        assert result.passed is True
+        assert result.skipped is False
+        assert result.fake_score == 0.05
+        assert result.confidence == 0.9
+        assert result.normalized_signals is not None
+        assert result.normalized_signals.category == "synthetic"
+        assert result.normalized_signals.synthetic_score == 0.05
+
+    def test_markdown_wrapped_json_is_parsed(self):
+        payload = json.dumps({
+            "is_deceptive": True,
+            "fake_likelihood": 0.75,
+            "confidence": 0.75,
+            "signals": ["diffusion artifacts"],
+            "flags": ["DIFFUSION_ARTIFACTS"],
+        })
+        _install_mock_genai(f"```json\n{payload}\n```")
+        try:
+            result = run(GeminiVisionCheck(project="test-project").run(_jpeg_bytes(), {}))
+        finally:
+            _remove_mock_genai()
+
+        assert result.passed is False
+        assert result.confidence == 0.75
+
+    def test_json_parse_failure_fails_closed(self):
+        _install_mock_genai("sorry, I cannot analyze this image")
+        try:
+            result = run(GeminiVisionCheck(project="test-project").run(_jpeg_bytes(), {}))
+        finally:
+            _remove_mock_genai()
+
+        assert result.skipped is False
+        assert result.passed is False
+        assert result.fake_score == 1.0
+        assert result.confidence == 1.0
+        assert "GEMINI_PARSE_ERROR" in result.flags
+        assert "JSON parse error" in result.error
+
+    def test_api_exception_fails_closed(self):
+        mock_client = MagicMock()
+        mock_client.models.generate_content.side_effect = RuntimeError("quota exceeded")
+        mock_genai = MagicMock()
+        mock_genai.Client.return_value = mock_client
+        sys.modules["google.genai"] = mock_genai
+        sys.modules["google.genai.types"] = MagicMock()
+        try:
+            result = run(GeminiVisionCheck(project="test-project").run(_jpeg_bytes(), {}))
+        finally:
+            _remove_mock_genai()
+
+        assert result.skipped is False
+        assert result.passed is False
+        assert result.fake_score == 1.0
+        assert result.confidence == 1.0
+        assert "CHECK_RUNTIME_ERROR" in result.flags
+        assert "quota exceeded" in result.error
+
+    def test_missing_project_fails_closed(self):
+        env_backup = os.environ.pop("GOOGLE_CLOUD_PROJECT", None)
+        sys.modules["google.genai"] = MagicMock()
+        sys.modules["google.genai.types"] = MagicMock()
+        try:
+            result = run(GeminiVisionCheck(project=None).run(_jpeg_bytes(), {}))
+        finally:
+            _remove_mock_genai()
+            if env_backup is not None:
+                os.environ["GOOGLE_CLOUD_PROJECT"] = env_backup
+
+        assert result.skipped is False
+        assert result.passed is False
+        assert result.fake_score == 1.0
+        assert result.confidence == 1.0
+        assert "CHECK_RUNTIME_ERROR" in result.flags
+        assert "GOOGLE_CLOUD_PROJECT" in result.error
+
+    def test_confidence_clamped_above_one(self):
+        _install_mock_genai(json.dumps({
+            "is_deceptive": True,
+            "confidence": 1.5,
+            "signals": [],
+            "flags": [],
+        }))
+        try:
+            result = run(GeminiVisionCheck(project="test-project").run(_jpeg_bytes(), {}))
+        finally:
+            _remove_mock_genai()
+
+        assert result.confidence == 1.0
+
+    def test_confidence_clamped_below_zero(self):
+        _install_mock_genai(json.dumps({
+            "is_deceptive": False,
+            "fake_likelihood": 0.0,
+            "confidence": -0.3,
+            "signals": [],
+            "flags": ["CLEAN"],
+        }))
+        try:
+            result = run(GeminiVisionCheck(project="test-project").run(_jpeg_bytes(), {}))
+        finally:
+            _remove_mock_genai()
+
+        assert result.confidence == 0.0  # clamp(-0.3) = 0.0
+        assert result.fake_score == 0.0
+
+    def test_document_context_is_sanitized_in_prompt_and_signals(self):
+        mock_client = _install_mock_genai(json.dumps({
+            "is_deceptive": False,
+            "fake_likelihood": 0.1,
+            "confidence": 0.8,
+            "signals": [],
+            "flags": ["CLEAN"],
+        }))
+        try:
+            result = run(GeminiVisionCheck(project="test-project").run(
+                _jpeg_bytes(),
+                {"doc_type": "passport<script>alert(1)</script>", "country": "u s-1; DROP"},
+            ))
+        finally:
+            _remove_mock_genai()
+
+        assert result.skipped is False
+        assert result.signals["doc_type"] == "passportscriptalert1script"
+        assert result.signals["country"] == "US1"
+        assert result.normalized_signals is not None
+        assert result.normalized_signals.category == "document_authenticity"
+        assert result.normalized_signals.document_type == "passportscriptalert1script"
+        assert result.normalized_signals.country_code == "US1"
+        prompt = mock_client.models.generate_content.call_args.kwargs["contents"][1]
+        assert "passportscriptalert1script" in prompt
+        assert "from US1" in prompt
+
+    def test_json_parse_failure_includes_bounded_raw_snippet(self):
+        _install_mock_genai("not json at all")
+        try:
+            result = run(GeminiVisionCheck(project="test-project").run(_jpeg_bytes(), {}))
+        finally:
+            _remove_mock_genai()
+
+        assert "GEMINI_PARSE_ERROR" in result.flags
+        assert "raw_snippet='not json at all'" in result.error

--- a/tests/unit/tools/fake_image_detector/test_gemini_vision_check.py
+++ b/tests/unit/tools/fake_image_detector/test_gemini_vision_check.py
@@ -63,10 +63,29 @@ class TestGeminiVisionCheck:
         assert result.fake_score == 0.87
         assert result.confidence == 0.87
         assert "GAN_ARTIFACTS" in result.flags
+        assert "EDITING_ARTIFACTS" in result.flags
+        assert result.human_escalate is False
         assert result.signals["is_deceptive"] is True
         assert result.normalized_signals is not None
         assert result.normalized_signals.category == "synthetic"
         assert result.normalized_signals.synthetic_score == 0.87
+
+    def test_possible_stock_flag_triggers_hard_escalation(self):
+        _install_mock_genai(json.dumps({
+            "is_deceptive": True,
+            "fake_likelihood": 0.7,
+            "confidence": 0.8,
+            "signals": ["looks like stock imagery"],
+            "flags": ["STOCK_PHOTO_INDICATORS"],
+        }))
+        try:
+            result = run(GeminiVisionCheck(project="test-project").run(_jpeg_bytes(), {}))
+        finally:
+            _remove_mock_genai()
+
+        assert "POSSIBLE_STOCK" in result.flags
+        assert result.human_escalate is True
+        assert any("POSSIBLE_STOCK" in reason for reason in result.escalation_reasons)
 
     def test_passes_real_image(self):
         _install_mock_genai(json.dumps({

--- a/tests/unit/tools/fake_image_detector/test_mrz_check.py
+++ b/tests/unit/tools/fake_image_detector/test_mrz_check.py
@@ -1,0 +1,108 @@
+import asyncio
+import sys
+from unittest.mock import MagicMock
+
+from tools.fake_image_detector.checks.mrz_check import MRZCheck
+
+
+def run(coro):
+    return asyncio.run(coro)
+
+
+def _install_mock_passporteye(mrz_dict: dict | None) -> None:
+    mock_mrz = None
+    if mrz_dict is not None:
+        mock_mrz = MagicMock()
+        mock_mrz.to_dict.return_value = mrz_dict
+
+    mock_module = MagicMock()
+    mock_module.read_mrz.return_value = mock_mrz
+    sys.modules["passporteye"] = mock_module
+
+
+def _remove_mock_passporteye() -> None:
+    sys.modules.pop("passporteye", None)
+
+
+class TestMRZCheck:
+    def test_check_id(self):
+        assert MRZCheck.check_id == "mrz"
+
+    def test_skips_when_passporteye_not_installed(self):
+        sys.modules["passporteye"] = None  # type: ignore[assignment]
+        try:
+            result = run(MRZCheck().run(b"img", {}))
+        finally:
+            sys.modules.pop("passporteye", None)
+
+        assert result.skipped is True
+        assert result.passed is True
+        assert result.confidence == 0.0
+        assert result.error is not None
+
+    def test_skips_when_no_mrz_detected(self):
+        _install_mock_passporteye(None)
+        try:
+            result = run(MRZCheck().run(b"img", {}))
+        finally:
+            _remove_mock_passporteye()
+
+        assert result.skipped is True
+        assert result.passed is True
+        assert result.confidence == 0.0
+
+    def test_passes_with_full_valid_score(self):
+        _install_mock_passporteye({
+            "valid_score": 100,
+            "type": "P",
+            "country": "DEU",
+        })
+        try:
+            result = run(MRZCheck().run(b"img", {}))
+        finally:
+            _remove_mock_passporteye()
+
+        assert result.passed is True
+        assert result.skipped is False
+        assert result.fake_score == 0.0
+        assert result.confidence == 1.0
+        assert result.signals["type"] == "P"
+        assert result.signals["country"] == "DEU"
+        assert result.normalized_signals is not None
+        assert result.normalized_signals.category == "document_authenticity"
+        assert "MRZ_VALID" in result.normalized_signals.indicators
+        assert result.normalized_signals.document_type == "P"
+        assert result.normalized_signals.country_code == "DEU"
+
+    def test_skips_on_partial_mrz_read(self):
+        _install_mock_passporteye({
+            "valid_score": 60,
+            "type": "P",
+            "country": "KEN",
+        })
+        try:
+            result = run(MRZCheck().run(b"img", {}))
+        finally:
+            _remove_mock_passporteye()
+
+        assert result.skipped is True
+        assert result.passed is True
+        assert result.confidence == 0.0
+        assert result.signals["valid_score"] == 60
+        assert result.signals["type"] == "P"
+        assert result.normalized_signals is not None
+        assert "MRZ_PARTIAL_READ" in result.normalized_signals.indicators
+
+    def test_skips_when_read_mrz_raises(self):
+        mock_module = MagicMock()
+        mock_module.read_mrz.side_effect = RuntimeError("corrupt scan")
+        sys.modules["passporteye"] = mock_module
+        try:
+            result = run(MRZCheck().run(b"bad", {}))
+        finally:
+            _remove_mock_passporteye()
+
+        assert result.skipped is True
+        assert result.passed is True
+        assert result.confidence == 0.0
+        assert result.error is not None

--- a/tests/unit/tools/fake_image_detector/test_ocr_document_check.py
+++ b/tests/unit/tools/fake_image_detector/test_ocr_document_check.py
@@ -1,0 +1,148 @@
+import asyncio
+import io
+import sys
+from unittest.mock import MagicMock, patch
+
+from PIL import Image
+
+from tools.fake_image_detector.checks.ocr_document_check import OCRDocumentCheck
+
+
+def run(coro):
+    return asyncio.run(coro)
+
+
+def _jpeg_bytes(width=64, height=64) -> bytes:
+    img = Image.new("RGB", (width, height), color=(200, 200, 200))
+    buf = io.BytesIO()
+    img.save(buf, format="JPEG")
+    return buf.getvalue()
+
+
+def _install_mock_tesseract(extracted_text: str) -> None:
+    mock_pytesseract = MagicMock()
+    mock_pytesseract.image_to_string.return_value = extracted_text
+    sys.modules["pytesseract"] = mock_pytesseract
+
+
+def _remove_mock_tesseract() -> None:
+    sys.modules.pop("pytesseract", None)
+
+
+class TestOCRDocumentCheckSkip:
+    def test_check_id(self):
+        assert OCRDocumentCheck.check_id == "ocr_document"
+
+    def test_skips_when_pytesseract_not_installed(self):
+        sys.modules["pytesseract"] = None  # type: ignore[assignment]
+        try:
+            result = run(OCRDocumentCheck().run(_jpeg_bytes(), {}))
+        finally:
+            sys.modules.pop("pytesseract", None)
+
+        assert result.skipped is True
+        assert result.passed is True
+        assert result.confidence == 0.0
+        assert result.error is not None
+
+    def test_skips_when_no_document_keywords_found(self):
+        _install_mock_tesseract("hello world this is a random image")
+        try:
+            result = run(OCRDocumentCheck().run(_jpeg_bytes(), {}))
+        finally:
+            _remove_mock_tesseract()
+
+        assert result.skipped is True
+        assert result.passed is True
+
+    def test_skips_on_ocr_error(self):
+        mock_pytesseract = MagicMock()
+        mock_pytesseract.image_to_string.side_effect = RuntimeError("tesseract not found")
+        sys.modules["pytesseract"] = mock_pytesseract
+        try:
+            result = run(OCRDocumentCheck().run(_jpeg_bytes(), {}))
+        finally:
+            _remove_mock_tesseract()
+
+        assert result.skipped is True
+        assert result.passed is True
+        assert result.error is not None
+
+
+class TestOCRDocumentCheckDetection:
+    def test_detects_passport_from_keyword(self):
+        _install_mock_tesseract("REPUBLIC OF KENYA\nPASSPORT\nName: John Doe")
+        context: dict = {}
+        try:
+            result = run(OCRDocumentCheck().run(_jpeg_bytes(), context))
+        finally:
+            _remove_mock_tesseract()
+
+        assert result.skipped is True
+        assert result.passed is True
+        assert context["doc_type"] == "passport"
+        assert result.signals["doc_type"] == "passport"
+        assert result.normalized_signals is not None
+        assert result.normalized_signals.document_type == "passport"
+        assert "DOCUMENT_DETECTED" in result.normalized_signals.indicators
+
+    def test_detects_national_id_from_keyword(self):
+        _install_mock_tesseract("IDENTITY CARD\nNational ID Number: 12345678")
+        context: dict = {}
+        try:
+            result = run(OCRDocumentCheck().run(_jpeg_bytes(), context))
+        finally:
+            _remove_mock_tesseract()
+
+        assert context["doc_type"] == "national_id"
+
+    def test_detects_bank_statement_from_iban_keyword(self):
+        _install_mock_tesseract("Bank Statement\nIBAN: DE89370400440532013000")
+        context: dict = {}
+        try:
+            result = run(OCRDocumentCheck().run(_jpeg_bytes(), context))
+        finally:
+            _remove_mock_tesseract()
+
+        assert context["doc_type"] == "bank_statement"
+
+    def test_detects_germany_country_from_text(self):
+        _install_mock_tesseract("REISEPASS\nBundesrepublik Deutschland\nName: Müller")
+        context: dict = {}
+        try:
+            run(OCRDocumentCheck().run(_jpeg_bytes(), context))
+        finally:
+            _remove_mock_tesseract()
+
+        assert context.get("doc_type") == "passport"
+        assert context.get("country") == "DE"
+
+    def test_detects_kenya_country_from_text(self):
+        _install_mock_tesseract("PASSPORT\nRepublic of Kenya\nName: Kamau")
+        context: dict = {}
+        try:
+            run(OCRDocumentCheck().run(_jpeg_bytes(), context))
+        finally:
+            _remove_mock_tesseract()
+
+        assert context.get("country") == "KE"
+
+    def test_does_not_overwrite_existing_country_in_context(self):
+        _install_mock_tesseract("PASSPORT\nRepublic of Kenya\nName: Kamau")
+        context: dict = {"country": "NG"}
+        try:
+            run(OCRDocumentCheck().run(_jpeg_bytes(), context))
+        finally:
+            _remove_mock_tesseract()
+
+        assert context["country"] == "NG"
+
+    def test_sets_doc_type_in_context_for_downstream_checks(self):
+        _install_mock_tesseract("Birth Certificate\nName: Anna Schmidt\nDate of Birth: 01.01.2000")
+        context: dict = {}
+        try:
+            run(OCRDocumentCheck().run(_jpeg_bytes(), context))
+        finally:
+            _remove_mock_tesseract()
+
+        assert context["doc_type"] == "birth_certificate"

--- a/tests/unit/tools/fake_image_detector/test_pipeline.py
+++ b/tests/unit/tools/fake_image_detector/test_pipeline.py
@@ -35,9 +35,11 @@ def _pipeline(
 def _passing(check_id: str) -> CheckResult:
     return CheckResult(check=check_id, passed=True, fake_score=0.0, confidence=0.8)
 
+
 def _ambiguous(check_id: str) -> CheckResult:
     # score = 0.5*0.8 / 0.8 = 0.5 → ambiguous zone [0.2, 0.8)
     return CheckResult(check=check_id, passed=False, fake_score=0.5, confidence=0.8)
+
 
 def _failing(check_id: str) -> CheckResult:
     # score = 1.0*0.9 / 0.9 = 1.0 → clear fail ≥ 0.8
@@ -82,6 +84,26 @@ def test_check_runtime_error_flags_immediately():
     assert result.escalation == Escalation.HUMAN_REVIEW
     assert result.early_exit is True
     assert "CHECK_RUNTIME_ERROR" in result.checks[0].flags
+
+
+def test_hard_escalation_flag_forces_human_review_before_score_classification():
+    reverse_image = _StubCheck(
+        CheckResult(
+            check="reverse_image",
+            passed=False,
+            fake_score=0.95,
+            confidence=0.95,
+            flags=["FOUND_ONLINE"],
+            human_escalate=True,
+            escalation_reasons=["FOUND_ONLINE detected by reverse_image check"],
+        )
+    )
+    p = _pipeline([(_cfg("reverse_image"), reverse_image)])
+    result = run(p.run(b"img", {"input_type": "face"}))
+    assert result.early_exit is True
+    assert result.verdict == Verdict.FLAG
+    assert result.escalation == Escalation.HUMAN_REVIEW
+    assert "hard escalation" in (result.early_exit_reason or "")
 
 
 def test_early_exit_on_fail_uses_fake_score():
@@ -131,14 +153,24 @@ def test_gemini_skipped_returns_stage1_with_skip_record():
     assert any(r.check == "gemini_vision" and r.skipped for r in result.checks)
 
 
-def test_gemini_fake_score_drives_final_verdict():
+def test_gemini_hard_escalation_overrides_clear_reject():
     ela = _StubCheck(_ambiguous("ela"))
-    gemini = _StubCheck(CheckResult(check="gemini_vision", passed=False, fake_score=0.85, confidence=0.87, flags=["GAN_ARTIFACTS"]))
+    gemini = _StubCheck(
+        CheckResult(
+            check="gemini_vision",
+            passed=False,
+            fake_score=0.95,
+            confidence=0.95,
+            flags=["POSSIBLE_STOCK"],
+            human_escalate=True,
+            escalation_reasons=["POSSIBLE_STOCK detected by gemini_vision check"],
+        )
+    )
     p = _pipeline([(_cfg("ela"), ela)], gemini_check=gemini)
     result = run(p.run(b"img", {"input_type": "face"}))
-    assert result.verdict == Verdict.REJECT
-    assert result.escalation == Escalation.AUTO_REJECT
-    assert result.risk_score == 0.85
+    assert result.verdict == Verdict.FLAG
+    assert result.escalation == Escalation.HUMAN_REVIEW
+    assert result.early_exit is True
 
 
 def test_gemini_real_verdict_overrides_ambiguous_stage1():

--- a/tests/unit/tools/fake_image_detector/test_reverse_image_check.py
+++ b/tests/unit/tools/fake_image_detector/test_reverse_image_check.py
@@ -35,7 +35,8 @@ class TestReverseImageCheck:
 
         assert result.passed is False
         assert result.fake_score == 1.0
-        assert "STOCK_PHOTO_REUSE" in result.flags
+        assert "POSSIBLE_STOCK" in result.flags
+        assert result.human_escalate is True
         assert result.normalized_signals is not None
         assert result.normalized_signals.category == "staging"
 
@@ -51,6 +52,7 @@ class TestReverseImageCheck:
 
         assert result.passed is False
         assert "FOUND_ONLINE" in result.flags
+        assert result.human_escalate is True
         assert result.signals["provider"] == "google_vision_web_detection"
 
     def test_search_failure_returns_skipped_unavailable(self):

--- a/tests/unit/tools/fake_image_detector/test_reverse_image_check.py
+++ b/tests/unit/tools/fake_image_detector/test_reverse_image_check.py
@@ -1,0 +1,69 @@
+import asyncio
+
+from tools.fake_image_detector.checks.reverse_image_check import ReverseImageCheck, _VisionResult
+
+
+def run(coro):
+    return asyncio.run(coro)
+
+
+class TestReverseImageCheck:
+    def test_check_id(self):
+        assert ReverseImageCheck.check_id == "reverse_image"
+
+    def test_no_match_returns_pass_with_no_match_flag(self):
+        check = ReverseImageCheck()
+        check._search_vision = lambda _img: _VisionResult(exact_count=0, similar_count=0, top_urls=[])  # type: ignore[attr-defined]
+
+        result = run(check.run(b"img", {}))
+
+        assert result.passed is True
+        assert result.skipped is False
+        assert result.fake_score == 0.0
+        assert "NO_MATCH" in result.flags
+        assert result.signals["provider"] == "google_vision_web_detection"
+
+    def test_stock_domain_reuse_returns_reject_signal(self):
+        check = ReverseImageCheck()
+        check._search_vision = lambda _img: _VisionResult(  # type: ignore[attr-defined]
+            exact_count=1,
+            similar_count=0,
+            top_urls=["https://www.shutterstock.com/image-photo/example"],
+        )
+
+        result = run(check.run(b"img", {}))
+
+        assert result.passed is False
+        assert result.fake_score == 1.0
+        assert "STOCK_PHOTO_REUSE" in result.flags
+        assert result.normalized_signals is not None
+        assert result.normalized_signals.category == "staging"
+
+    def test_exact_match_on_nonlisted_domains_returns_found_online(self):
+        check = ReverseImageCheck()
+        check._search_vision = lambda _img: _VisionResult(  # type: ignore[attr-defined]
+            exact_count=2,
+            similar_count=0,
+            top_urls=["https://example.com/reused-photo"],
+        )
+
+        result = run(check.run(b"img", {}))
+
+        assert result.passed is False
+        assert "FOUND_ONLINE" in result.flags
+        assert result.signals["provider"] == "google_vision_web_detection"
+
+    def test_search_failure_returns_skipped_unavailable(self):
+        check = ReverseImageCheck(params={"max_retries": 2})
+
+        def _boom(_img):
+            raise RuntimeError("vision unavailable")
+
+        check._search_vision = _boom  # type: ignore[attr-defined]
+
+        result = run(check.run(b"img", {}))
+
+        assert result.skipped is True
+        assert result.passed is True
+        assert "REVERSE_SEARCH_UNAVAILABLE" in result.flags
+        assert "errors" in result.signals

--- a/tools/fake_image_detector/checks/cnn_deepfake_check.py
+++ b/tools/fake_image_detector/checks/cnn_deepfake_check.py
@@ -1,0 +1,125 @@
+import asyncio
+import io
+from pathlib import Path
+
+import numpy as np
+
+from tools.fake_image_detector.checks.base_check import BaseCheck
+from tools.fake_image_detector.models import CheckResult, NormalizedSignals
+
+_MODEL_DIR = Path(__file__).parent.parent / "models"
+_DEFAULT_MODEL = _MODEL_DIR / "cnn_deepfake.onnx"
+_FALLBACK_MODEL = _MODEL_DIR / "cnn_deepfake_int8.onnx"
+
+# ViT preprocessing constants (preprocessor_config.json from HuggingFace)
+_MEAN = np.array([0.5, 0.5, 0.5], dtype=np.float32)
+_STD = np.array([0.5, 0.5, 0.5], dtype=np.float32)
+_INPUT_SIZE = 224
+
+# P(deepfake) above this threshold → flag
+_THRESHOLD = 0.5
+
+
+def _find_model() -> Path | None:
+    for candidate in (_DEFAULT_MODEL, _FALLBACK_MODEL):
+        if candidate.exists():
+            return candidate
+    return None
+
+
+def _softmax(x: np.ndarray) -> np.ndarray:
+    e = np.exp(x - x.max())
+    return e / e.sum()
+
+
+class CNNDeepfakeCheck(BaseCheck):
+    check_id = "cnn_deepfake"
+
+    def __init__(self, params: dict | None = None, model_path: Path | None = None):
+        self._model_path = model_path or _find_model()
+        self._session = None
+
+    def _get_session(self):
+        if self._session is not None:
+            return self._session
+        import onnxruntime as ort
+        opts = ort.SessionOptions()
+        opts.log_severity_level = 3  # suppress verbose ONNX logs
+        self._session = ort.InferenceSession(str(self._model_path), sess_options=opts)
+        return self._session
+
+    async def run(self, image_bytes: bytes, context: dict) -> CheckResult:
+        return await asyncio.to_thread(self._run_sync, image_bytes)
+
+    def _run_sync(self, image_bytes: bytes) -> CheckResult:
+        if self._model_path is None or not self._model_path.exists():
+            return CheckResult(
+                check=self.check_id,
+                passed=True,
+                confidence=0.0,
+                skipped=True,
+                error="MODEL_NOT_AVAILABLE",
+            )
+
+        try:
+            from PIL import Image
+        except ImportError as e:
+            return CheckResult(check=self.check_id, passed=True, confidence=0.0, skipped=True, error=str(e))
+
+        try:
+            img = Image.open(io.BytesIO(image_bytes)).convert("RGB")
+            img = img.resize((_INPUT_SIZE, _INPUT_SIZE), Image.Resampling.BILINEAR)
+        except Exception as e:
+            return CheckResult(check=self.check_id, passed=True, confidence=0.0, skipped=True, error=str(e))
+
+        try:
+            session = self._get_session()
+        except Exception as e:
+            return CheckResult(check=self.check_id, passed=True, confidence=0.0, skipped=True, error=str(e))
+
+        arr = np.array(img, dtype=np.float32) / 255.0
+        arr = (arr - _MEAN) / _STD
+        tensor = arr.transpose(2, 0, 1)[np.newaxis]  # HWC → NCHW
+
+        try:
+            input_name = session.get_inputs()[0].name
+            output_name = session.get_outputs()[0].name
+            logits = session.run([output_name], {input_name: tensor})[0][0]
+        except Exception as e:
+            return CheckResult(check=self.check_id, passed=True, confidence=0.0, skipped=True, error=str(e))
+
+        probs = _softmax(logits.astype(np.float32))
+        p_fake = float(probs[0])  # index 0 = Deepfake
+        p_real = float(probs[1])  # index 1 = Real
+
+        decisiveness = round(max(p_fake, p_real), 3)  # how far from 50/50
+
+        if p_fake >= _THRESHOLD:
+            return CheckResult(
+                check=self.check_id,
+                passed=False,
+                fake_score=round(p_fake, 3),
+                confidence=decisiveness,
+                flags=["CNN_DEEPFAKE_DETECTED"],
+                signals={"p_fake": round(p_fake, 3), "p_real": round(p_real, 3)},
+                normalized_signals=NormalizedSignals(
+                    category="synthetic",
+                    confidence=decisiveness,
+                    indicators=["CNN_DEEPFAKE_DETECTED"],
+                    synthetic_score=round(p_fake, 3),
+                ),
+            )
+
+        return CheckResult(
+            check=self.check_id,
+            passed=True,
+            fake_score=round(p_fake, 3),
+            confidence=decisiveness,
+            signals={"p_fake": round(p_fake, 3), "p_real": round(p_real, 3)},
+            normalized_signals=NormalizedSignals(
+                category="synthetic",
+                confidence=decisiveness,
+                indicators=["CLEAN"],
+                synthetic_score=round(p_fake, 3),
+            ),
+        )

--- a/tools/fake_image_detector/checks/gemini_extract_check.py
+++ b/tools/fake_image_detector/checks/gemini_extract_check.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import re
+
+from tools.fake_image_detector.checks.base_check import BaseCheck
+from tools.fake_image_detector.models import CheckResult
+
+# Fields to extract per document type, based on what each document typically contains.
+_EXTRACT_FIELDS: dict[str, list[str]] = {
+    "passport": ["full_name", "document_number", "date_of_birth", "expiry_date", "nationality"],
+    "national_id": ["full_name", "id_number", "date_of_birth", "expiry_date"],
+    "birth_certificate": ["full_name", "date_of_birth", "place_of_birth", "signed_by"],
+    "death_certificate": ["full_name", "date_of_death", "place_of_death", "signed_by"],
+    "driving_license": ["full_name", "licence_number", "date_of_birth", "expiry_date"],
+    "bank_statement": ["account_holder", "iban", "account_number"],
+}
+
+_EXTRACT_PROMPT_TEMPLATE = """\
+This image contains a {doc_type}. Extract the following fields exactly as they appear in the document:
+
+{field_list}
+
+Respond ONLY with a valid JSON object. Use null for any field that is not visible or not present.
+Example: {{"full_name": "Max Mustermann", "date_of_birth": "1985-03-15"}}
+Do not include any text outside the JSON object.\
+"""
+
+_JSON_RE = re.compile(r"\{.*\}", re.DOTALL)
+
+
+def _sniff_mime(image_bytes: bytes) -> str:
+    if image_bytes[:2] == b"\xff\xd8":
+        return "image/jpeg"
+    if image_bytes[:4] == b"\x89PNG":
+        return "image/png"
+    if len(image_bytes) >= 12 and image_bytes[8:12] == b"WEBP":
+        return "image/webp"
+    return "image/jpeg"
+
+
+class GeminiExtractCheck(BaseCheck):
+    check_id = "gemini_extract"
+
+    def __init__(self, params: dict | None = None, project: str | None = None, location: str | None = None):
+        self._project = project or os.environ.get("GOOGLE_CLOUD_PROJECT")
+        self._location = location or os.environ.get("VERTEX_LOCATION", "us-central1")
+
+    async def run(self, image_bytes: bytes, context: dict) -> CheckResult:
+        return await asyncio.to_thread(self._run_sync, image_bytes, context)
+
+    def _run_sync(self, image_bytes: bytes, context: dict) -> CheckResult:
+        doc_type = context.get("doc_type")
+        if not doc_type:
+            return CheckResult(check=self.check_id, passed=True, confidence=0.0, skipped=True)
+
+        fields = _EXTRACT_FIELDS.get(doc_type)
+        if not fields:
+            return CheckResult(check=self.check_id, passed=True, confidence=0.0, skipped=True)
+
+        try:
+            from google import genai
+            from google.genai import types as gentypes
+        except ImportError as e:
+            return CheckResult(check=self.check_id, passed=True, confidence=0.0, skipped=True, error=str(e))
+
+        if not self._project:
+            return CheckResult(
+                check=self.check_id, passed=True, confidence=0.0,
+                skipped=True, error="GOOGLE_CLOUD_PROJECT not set",
+            )
+
+        field_list = "\n".join(f"- {f}" for f in fields)
+        prompt = _EXTRACT_PROMPT_TEMPLATE.format(
+            doc_type=doc_type.replace("_", " "),
+            field_list=field_list,
+        )
+        model = os.environ.get("VERTEX_MODEL", "gemini-2.5-flash")
+
+        try:
+            client = genai.Client(
+                vertexai=True, project=self._project, location=self._location
+            )
+            image_part = gentypes.Part.from_bytes(
+                data=image_bytes, mime_type=_sniff_mime(image_bytes)
+            )
+            response = client.models.generate_content(
+                model=model, contents=[image_part, prompt]
+            )
+            raw = response.text
+        except Exception as e:
+            return CheckResult(check=self.check_id, passed=True, confidence=0.0, skipped=True, error=str(e))
+
+        try:
+            match = _JSON_RE.search(raw)
+            if not match:
+                raise ValueError("no JSON object in response")
+            extracted = json.loads(match.group())
+        except Exception as e:
+            return CheckResult(
+                check=self.check_id, passed=True, confidence=0.0,
+                skipped=True, error=f"JSON parse error: {e}",
+            )
+
+        # Drop null values; store the rest for downstream checks and the auth prompt
+        extracted_fields = {k: v for k, v in extracted.items() if v is not None}
+        context["extracted_fields"] = extracted_fields
+
+        return CheckResult(
+            check=self.check_id,
+            passed=True,
+            confidence=0.0,
+            skipped=True,
+            signals={"doc_type": doc_type, "extracted": extracted_fields},
+        )

--- a/tools/fake_image_detector/checks/gemini_vision_check.py
+++ b/tools/fake_image_detector/checks/gemini_vision_check.py
@@ -15,6 +15,7 @@ _PHOTO_PROMPT = """You are a fraud-detection assistant. Analyze this image and a
 3. STAGED or STOCK — a professional shoot, stock image, or heavily posed photo unlikely to be a genuine personal submission.
 4. BACKGROUND INCONSISTENCY — background does not match the subject (composited, greenscreen, mismatched lighting).
 5. LIGHTING or SHADOW INCONSISTENCY — light sources or shadows are inconsistent across the image.
+6. AGE INCONSISTENCY — the estimated age of the subject does not match the age that would be expected for a genuine personal submission (e.g. the photo appears to show a much older or younger person than the context suggests).
 
 Do NOT make a final verdict. Report only the signals you observe.
 
@@ -23,10 +24,11 @@ Respond ONLY with valid JSON matching this schema:
   "is_deceptive": <bool, true if the image is AI-generated, manipulated, staged, or otherwise not a genuine personal photo>,
   "fake_likelihood": <float 0.0-1.0, probability the image is deceptive>,
   "confidence": <float 0.0-1.0, how certain you are about your assessment>,
-  "signals": [<list of short specific observed-indicator strings, e.g. "skin texture too smooth", "background composited">],
+  "estimated_age": <integer or null, estimated age of the primary subject in years, null if no person is visible>,
+  "signals": [<list of short specific observed-indicator strings, e.g. "skin texture too smooth", "background composited", "subject appears 40+ years old">],
   "flags": [<zero or more from: GAN_ARTIFACTS, DIFFUSION_ARTIFACTS, EDITING_DETECTED,
              INCONSISTENT_LIGHTING, UNNATURAL_TEXTURE, BACKGROUND_INCONSISTENCY,
-             STOCK_PHOTO_INDICATORS, STAGING_ARTIFACTS, METADATA_MISMATCH, CLEAN>]
+             STOCK_PHOTO_INDICATORS, STAGING_ARTIFACTS, METADATA_MISMATCH, AGE_INCONSISTENCY, CLEAN>]
 }
 Do not include any text outside the JSON object."""
 
@@ -40,6 +42,7 @@ Assess whether this appears to be a GENUINE, AUTHENTIC document or whether it is
 3. DIGITALLY MANIPULATED — an authentic document with altered fields (name, date, number).
 4. TEMPLATE DETECTED — produced from an online template without official security features.
 5. INCONSISTENT SECURITY FEATURES — missing expected holograms, watermarks, or official markings.
+6. LANGUAGE INCONSISTENCY — the language or script used in the document does not match what is expected for the claimed country or document type (e.g. an English-only passport from a non-English-issuing country, mismatched official seals or text).
 
 Do NOT make a final verdict. Report only the signals you observe.
 
@@ -48,9 +51,9 @@ Respond ONLY with valid JSON matching this schema:
   "is_deceptive": <bool, true if the document appears forged, altered, or not genuine>,
   "fake_likelihood": <float 0.0-1.0, probability the document is not genuine>,
   "confidence": <float 0.0-1.0, how certain you are about your assessment>,
-  "signals": [<list of short specific observed-indicator strings, e.g. "no visible hologram", "font inconsistency on expiry date">],
+  "signals": [<list of short specific observed-indicator strings, e.g. "no visible hologram", "font inconsistency on expiry date", "document language does not match issuing country">],
   "flags": [<zero or more from: FORGED_DOCUMENT, PHOTO_OF_PHOTO, EDITING_DETECTED,
-             TEMPLATE_DETECTED, INCONSISTENT_SECURITY_FEATURES, CLEAN>]
+             TEMPLATE_DETECTED, INCONSISTENT_SECURITY_FEATURES, LANGUAGE_INCONSISTENCY, CLEAN>]
 }}
 Do not include any text outside the JSON object.\
 """
@@ -194,10 +197,13 @@ class GeminiVisionCheck(BaseCheck):
         gemini_confidence = max(0.0, min(1.0, float(data.get("confidence", 0.0))))
         is_deceptive = bool(data.get("is_deceptive", data.get("is_synthetic", False)))
         flags = [str(f) for f in data.get("flags", [])]
+        raw_age = data.get("estimated_age")
+        estimated_age = int(raw_age) if raw_age is not None else None
         signals = {
             "doc_type": safe_doc_type if doc_type else None,
             "country": safe_country if doc_type else "",
             "is_deceptive": is_deceptive,
+            "estimated_age": estimated_age,
             "signals": data.get("signals", []),
         }
 

--- a/tools/fake_image_detector/checks/gemini_vision_check.py
+++ b/tools/fake_image_detector/checks/gemini_vision_check.py
@@ -6,7 +6,15 @@ import os
 import re
 
 from tools.fake_image_detector.checks.base_check import BaseCheck
-from tools.fake_image_detector.models import CheckResult, NormalizedSignals
+from tools.fake_image_detector.models import (
+    CheckResult,
+    GL9_FLAG_AGE_INCONSISTENCY,
+    GL9_FLAG_EDITING_ARTIFACTS,
+    GL9_FLAG_FOUND_ONLINE,
+    GL9_FLAG_POSSIBLE_STOCK,
+    GL9_HARD_ESCALATION_FLAGS,
+    NormalizedSignals,
+)
 
 _PHOTO_PROMPT = """You are a fraud-detection assistant. Analyze this image and assess whether it is a genuine, original photograph submitted by a real person, or whether it is deceptive in any of the following ways:
 
@@ -26,9 +34,9 @@ Respond ONLY with valid JSON matching this schema:
   "confidence": <float 0.0-1.0, how certain you are about your assessment>,
   "estimated_age": <integer or null, estimated age of the primary subject in years, null if no person is visible>,
   "signals": [<list of short specific observed-indicator strings, e.g. "skin texture too smooth", "background composited", "subject appears 40+ years old">],
-  "flags": [<zero or more from: GAN_ARTIFACTS, DIFFUSION_ARTIFACTS, EDITING_DETECTED,
+  "flags": [<zero or more from: GAN_ARTIFACTS, DIFFUSION_ARTIFACTS, EDITING_ARTIFACTS,
              INCONSISTENT_LIGHTING, UNNATURAL_TEXTURE, BACKGROUND_INCONSISTENCY,
-             STOCK_PHOTO_INDICATORS, STAGING_ARTIFACTS, METADATA_MISMATCH, AGE_INCONSISTENCY, CLEAN>]
+             POSSIBLE_STOCK, STAGING_ARTIFACTS, METADATA_MISMATCH, AGE_INCONSISTENCY, CLEAN>]
 }
 Do not include any text outside the JSON object."""
 
@@ -52,7 +60,7 @@ Respond ONLY with valid JSON matching this schema:
   "fake_likelihood": <float 0.0-1.0, probability the document is not genuine>,
   "confidence": <float 0.0-1.0, how certain you are about your assessment>,
   "signals": [<list of short specific observed-indicator strings, e.g. "no visible hologram", "font inconsistency on expiry date", "document language does not match issuing country">],
-  "flags": [<zero or more from: FORGED_DOCUMENT, PHOTO_OF_PHOTO, EDITING_DETECTED,
+  "flags": [<zero or more from: FORGED_DOCUMENT, PHOTO_OF_PHOTO, EDITING_ARTIFACTS,
              TEMPLATE_DETECTED, INCONSISTENT_SECURITY_FEATURES, LANGUAGE_INCONSISTENCY, CLEAN>]
 }}
 Do not include any text outside the JSON object.\
@@ -61,6 +69,22 @@ Do not include any text outside the JSON object.\
 # Strip optional markdown code fences Gemini sometimes wraps around JSON
 _JSON_RE = re.compile(r"\{.*\}", re.DOTALL)
 _SAFE_TOKEN_RE = re.compile(r"[^a-zA-Z0-9 _-]+")
+
+_FLAG_ALIASES = {
+    "EDITING_DETECTED": GL9_FLAG_EDITING_ARTIFACTS,
+    "STOCK_PHOTO_INDICATORS": GL9_FLAG_POSSIBLE_STOCK,
+    "STOCK_PHOTO_REUSE": GL9_FLAG_POSSIBLE_STOCK,
+    "FOUND_ONLINE_REUSE": GL9_FLAG_FOUND_ONLINE,
+}
+
+_EDITING_SOURCE_FLAGS = {
+    "GAN_ARTIFACTS",
+    "DIFFUSION_ARTIFACTS",
+    "INCONSISTENT_LIGHTING",
+    "UNNATURAL_TEXTURE",
+    "BACKGROUND_INCONSISTENCY",
+    "METADATA_MISMATCH",
+}
 
 
 def _sanitize_doc_type(value: object) -> str:
@@ -88,6 +112,22 @@ def _sniff_mime(image_bytes: bytes) -> str:
     if len(image_bytes) >= 12 and image_bytes[8:12] == b"WEBP":
         return "image/webp"
     return "image/jpeg"
+
+
+def _normalize_flags(raw_flags: list[str]) -> list[str]:
+    normalized: list[str] = []
+    for raw_flag in raw_flags:
+        canonical = _FLAG_ALIASES.get(raw_flag, raw_flag)
+        if canonical not in normalized:
+            normalized.append(canonical)
+
+    if any(flag in _EDITING_SOURCE_FLAGS for flag in normalized):
+        if GL9_FLAG_EDITING_ARTIFACTS not in normalized:
+            normalized.append(GL9_FLAG_EDITING_ARTIFACTS)
+
+    # AGE_INCONSISTENCY is already canonical; keep it if present and avoid duplicate insertions.
+
+    return normalized
 
 
 class GeminiVisionCheck(BaseCheck):
@@ -196,9 +236,14 @@ class GeminiVisionCheck(BaseCheck):
         fake_likelihood = max(0.0, min(1.0, float(data.get("fake_likelihood", 0.0))))
         gemini_confidence = max(0.0, min(1.0, float(data.get("confidence", 0.0))))
         is_deceptive = bool(data.get("is_deceptive", data.get("is_synthetic", False)))
-        flags = [str(f) for f in data.get("flags", [])]
+        flags = _normalize_flags([str(f) for f in data.get("flags", [])])
         raw_age = data.get("estimated_age")
         estimated_age = int(raw_age) if raw_age is not None else None
+        escalation_reasons = [
+            f"{flag} detected by gemini_vision check"
+            for flag in flags
+            if flag in GL9_HARD_ESCALATION_FLAGS
+        ]
         signals = {
             "doc_type": safe_doc_type if doc_type else None,
             "country": safe_country if doc_type else "",
@@ -223,7 +268,9 @@ class GeminiVisionCheck(BaseCheck):
                 synthetic_score=round(fake_likelihood, 3) if not doc_type else None,
                 manipulation_score=round(fake_likelihood, 3),
                 staging_score=round(fake_likelihood, 3) if any(
-                    f in {"STAGING_ARTIFACTS", "STOCK_PHOTO_INDICATORS"} for f in flags
+                    f in {"STAGING_ARTIFACTS", GL9_FLAG_POSSIBLE_STOCK} for f in flags
                 ) else None,
             ),
+            human_escalate=bool(escalation_reasons),
+            escalation_reasons=escalation_reasons,
         )

--- a/tools/fake_image_detector/checks/gemini_vision_check.py
+++ b/tools/fake_image_detector/checks/gemini_vision_check.py
@@ -1,0 +1,223 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import re
+
+from tools.fake_image_detector.checks.base_check import BaseCheck
+from tools.fake_image_detector.models import CheckResult, NormalizedSignals
+
+_PHOTO_PROMPT = """You are a fraud-detection assistant. Analyze this image and assess whether it is a genuine, original photograph submitted by a real person, or whether it is deceptive in any of the following ways:
+
+1. AI-GENERATED or SYNTHETIC — produced by a GAN, diffusion model, or other generative system.
+2. DIGITALLY MANIPULATED — a real photo that has been edited, composited, or had elements added/removed.
+3. STAGED or STOCK — a professional shoot, stock image, or heavily posed photo unlikely to be a genuine personal submission.
+4. BACKGROUND INCONSISTENCY — background does not match the subject (composited, greenscreen, mismatched lighting).
+5. LIGHTING or SHADOW INCONSISTENCY — light sources or shadows are inconsistent across the image.
+
+Do NOT make a final verdict. Report only the signals you observe.
+
+Respond ONLY with valid JSON matching this schema:
+{
+  "is_deceptive": <bool, true if the image is AI-generated, manipulated, staged, or otherwise not a genuine personal photo>,
+  "fake_likelihood": <float 0.0-1.0, probability the image is deceptive>,
+  "confidence": <float 0.0-1.0, how certain you are about your assessment>,
+  "signals": [<list of short specific observed-indicator strings, e.g. "skin texture too smooth", "background composited">],
+  "flags": [<zero or more from: GAN_ARTIFACTS, DIFFUSION_ARTIFACTS, EDITING_DETECTED,
+             INCONSISTENT_LIGHTING, UNNATURAL_TEXTURE, BACKGROUND_INCONSISTENCY,
+             STOCK_PHOTO_INDICATORS, STAGING_ARTIFACTS, METADATA_MISMATCH, CLEAN>]
+}
+Do not include any text outside the JSON object."""
+
+_DOCUMENT_PROMPT_TEMPLATE = """\
+You are a fraud-detection assistant. This image has been identified as a {doc_type}{country_clause}.
+{extracted_section}
+Assess whether this appears to be a GENUINE, AUTHENTIC document or whether it is deceptive in any of the following ways:
+
+1. FORGED or FABRICATED — a printed template, photoshop creation, or entirely made-up document.
+2. PHOTO OF A PHOTO — a photograph taken of another physical document or screen.
+3. DIGITALLY MANIPULATED — an authentic document with altered fields (name, date, number).
+4. TEMPLATE DETECTED — produced from an online template without official security features.
+5. INCONSISTENT SECURITY FEATURES — missing expected holograms, watermarks, or official markings.
+
+Do NOT make a final verdict. Report only the signals you observe.
+
+Respond ONLY with valid JSON matching this schema:
+{{
+  "is_deceptive": <bool, true if the document appears forged, altered, or not genuine>,
+  "fake_likelihood": <float 0.0-1.0, probability the document is not genuine>,
+  "confidence": <float 0.0-1.0, how certain you are about your assessment>,
+  "signals": [<list of short specific observed-indicator strings, e.g. "no visible hologram", "font inconsistency on expiry date">],
+  "flags": [<zero or more from: FORGED_DOCUMENT, PHOTO_OF_PHOTO, EDITING_DETECTED,
+             TEMPLATE_DETECTED, INCONSISTENT_SECURITY_FEATURES, CLEAN>]
+}}
+Do not include any text outside the JSON object.\
+"""
+
+# Strip optional markdown code fences Gemini sometimes wraps around JSON
+_JSON_RE = re.compile(r"\{.*\}", re.DOTALL)
+_SAFE_TOKEN_RE = re.compile(r"[^a-zA-Z0-9 _-]+")
+
+
+def _sanitize_doc_type(value: object) -> str:
+    if value is None:
+        return "document"
+    cleaned = _SAFE_TOKEN_RE.sub("", str(value)).strip().replace("_", " ")
+    cleaned = re.sub(r"\s+", " ", cleaned)
+    return cleaned[:64] if cleaned else "document"
+
+
+def _sanitize_country(value: object) -> str:
+    if value is None:
+        return ""
+    cleaned = _SAFE_TOKEN_RE.sub("", str(value)).strip().upper()
+    cleaned = re.sub(r"\s+", "", cleaned)
+    cleaned = re.sub(r"[^A-Z0-9]", "", cleaned)
+    return cleaned[:3]
+
+
+def _sniff_mime(image_bytes: bytes) -> str:
+    if image_bytes[:2] == b"\xff\xd8":
+        return "image/jpeg"
+    if image_bytes[:4] == b"\x89PNG":
+        return "image/png"
+    if len(image_bytes) >= 12 and image_bytes[8:12] == b"WEBP":
+        return "image/webp"
+    return "image/jpeg"
+
+
+class GeminiVisionCheck(BaseCheck):
+    check_id = "gemini_vision"
+
+    def __init__(
+        self,
+        project: str | None = None,
+        location: str | None = None,
+        timeout_seconds: float = 30.0,
+        max_retries: int = 3,
+    ):
+        self._project = project or os.environ.get("GOOGLE_CLOUD_PROJECT")
+        self._location = location or os.environ.get("VERTEX_LOCATION", "us-central1")
+        self._timeout_seconds = timeout_seconds
+        self._max_retries = max(1, max_retries)
+
+    async def run(self, image_bytes: bytes, context: dict) -> CheckResult:
+        try:
+            return await asyncio.wait_for(
+                asyncio.to_thread(self._run_sync, image_bytes, context),
+                timeout=self._timeout_seconds,
+            )
+        except TimeoutError:
+            return self._error_result("Gemini vision check timed out", "CHECK_TIMEOUT")
+
+    def _error_result(self, error: str, flag: str = "CHECK_RUNTIME_ERROR") -> CheckResult:
+        return CheckResult(
+            check=self.check_id,
+            passed=False,
+            fake_score=1.0,
+            confidence=1.0,
+            flags=[flag],
+            signals={"error": error},
+            skipped=False,
+            error=error,
+        )
+
+    def _run_sync(self, image_bytes: bytes, context: dict) -> CheckResult:
+        try:
+            from google import genai
+            from google.genai import types as gentypes
+        except ImportError as e:
+            return self._error_result(str(e))
+
+        if not self._project:
+            return self._error_result("GOOGLE_CLOUD_PROJECT not set")
+
+        doc_type = context.get("doc_type")
+        country = context.get("country")
+
+        if doc_type:
+            safe_doc_type = _sanitize_doc_type(doc_type)
+            safe_country = _sanitize_country(country)
+            country_clause = f" from {safe_country}" if safe_country else ""
+            extracted = context.get("extracted_fields", {})
+            if extracted:
+                lines = "\n".join(f"  - {k}: {v}" for k, v in extracted.items())
+                extracted_section = f"\nExtracted fields:\n{lines}\n"
+            else:
+                extracted_section = ""
+            prompt = _DOCUMENT_PROMPT_TEMPLATE.format(
+                doc_type=safe_doc_type,
+                country_clause=country_clause,
+                extracted_section=extracted_section,
+            )
+        else:
+            safe_doc_type = None
+            safe_country = ""
+            prompt = _PHOTO_PROMPT
+
+        model = os.environ.get("VERTEX_MODEL", "gemini-2.5-flash")
+
+        raw = ""
+        for attempt in range(self._max_retries):
+            try:
+                client = genai.Client(
+                    vertexai=True, project=self._project, location=self._location
+                )
+                image_part = gentypes.Part.from_bytes(
+                    data=image_bytes, mime_type=_sniff_mime(image_bytes)
+                )
+                response = client.models.generate_content(
+                    model=model, contents=[image_part, prompt]
+                )
+                raw = response.text
+                break
+            except Exception as e:
+                is_last_attempt = attempt == self._max_retries - 1
+                if is_last_attempt:
+                    return self._error_result(str(e))
+                continue
+
+        try:
+            match = _JSON_RE.search(raw)
+            if not match:
+                raise ValueError("no JSON object in response")
+            data = json.loads(match.group())
+        except Exception as e:
+            raw_snippet = raw[:120] if raw else ""
+            return self._error_result(
+                f"JSON parse error: {e}; raw_snippet={raw_snippet!r}",
+                "GEMINI_PARSE_ERROR",
+            )
+
+        fake_likelihood = max(0.0, min(1.0, float(data.get("fake_likelihood", 0.0))))
+        gemini_confidence = max(0.0, min(1.0, float(data.get("confidence", 0.0))))
+        is_deceptive = bool(data.get("is_deceptive", data.get("is_synthetic", False)))
+        flags = [str(f) for f in data.get("flags", [])]
+        signals = {
+            "doc_type": safe_doc_type if doc_type else None,
+            "country": safe_country if doc_type else "",
+            "is_deceptive": is_deceptive,
+            "signals": data.get("signals", []),
+        }
+
+        return CheckResult(
+            check=self.check_id,
+            passed=not is_deceptive,
+            fake_score=round(fake_likelihood, 3),
+            confidence=round(gemini_confidence, 3),
+            flags=flags,
+            signals=signals,
+            normalized_signals=NormalizedSignals(
+                category="document_authenticity" if doc_type else "synthetic",
+                confidence=round(gemini_confidence, 3),
+                indicators=flags or ["CLEAN"],
+                document_type=safe_doc_type if doc_type else None,
+                country_code=safe_country if doc_type else None,
+                synthetic_score=round(fake_likelihood, 3) if not doc_type else None,
+                manipulation_score=round(fake_likelihood, 3),
+                staging_score=round(fake_likelihood, 3) if any(
+                    f in {"STAGING_ARTIFACTS", "STOCK_PHOTO_INDICATORS"} for f in flags
+                ) else None,
+            ),
+        )

--- a/tools/fake_image_detector/checks/mrz_check.py
+++ b/tools/fake_image_detector/checks/mrz_check.py
@@ -1,0 +1,61 @@
+import asyncio
+import io
+
+from tools.fake_image_detector.checks.base_check import BaseCheck
+from tools.fake_image_detector.models import CheckResult, NormalizedSignals
+
+
+class MRZCheck(BaseCheck):
+    check_id = "mrz"
+
+    async def run(self, image_bytes: bytes, context: dict) -> CheckResult:
+        return await asyncio.to_thread(self._run_sync, image_bytes)
+
+    def _run_sync(self, image_bytes: bytes) -> CheckResult:
+        try:
+            from passporteye import read_mrz
+        except ImportError as e:
+            return CheckResult(check=self.check_id, passed=True, confidence=0.0, skipped=True, error=str(e))
+
+        try:
+            mrz = read_mrz(io.BytesIO(image_bytes))
+        except Exception as e:
+            return CheckResult(check=self.check_id, passed=True, confidence=0.0, skipped=True, error=str(e))
+
+        if mrz is None:
+            return CheckResult(check=self.check_id, passed=True, confidence=0.0, skipped=True)
+
+        data = mrz.to_dict()
+        valid_score = data.get("valid_score", 0)
+
+        if valid_score == 100:
+            return CheckResult(
+                check=self.check_id,
+                passed=True,
+                fake_score=0.0,
+                confidence=1.0,
+                signals={"type": data.get("type"), "country": data.get("country")},
+                normalized_signals=NormalizedSignals(
+                    category="document_authenticity",
+                    confidence=1.0,
+                    indicators=["MRZ_VALID"],
+                    document_type=data.get("type"),
+                    country_code=data.get("country"),
+                ),
+            )
+
+        # Partial read: phone-photo OCR errors cause checksum failures on real passports.
+        # Skip scoring and let Gemini validate — report the score for observability.
+        return CheckResult(
+            check=self.check_id,
+            passed=True,
+            confidence=0.0,
+            skipped=True,
+            signals={"valid_score": valid_score, "type": data.get("type")},
+            normalized_signals=NormalizedSignals(
+                category="document_authenticity",
+                confidence=0.0,
+                indicators=["MRZ_PARTIAL_READ"],
+                document_type=data.get("type"),
+            ),
+        )

--- a/tools/fake_image_detector/checks/ocr_document_check.py
+++ b/tools/fake_image_detector/checks/ocr_document_check.py
@@ -1,0 +1,83 @@
+import asyncio
+import io
+
+from tools.fake_image_detector.checks.base_check import BaseCheck
+from tools.fake_image_detector.config_loader import load_document_schemas
+from tools.fake_image_detector.models import CheckResult, NormalizedSignals
+
+_SCHEMAS = None
+
+
+def _get_schemas() -> dict:
+    global _SCHEMAS
+    if _SCHEMAS is None:
+        _SCHEMAS = load_document_schemas()
+    return _SCHEMAS
+
+
+class OCRDocumentCheck(BaseCheck):
+    check_id = "ocr_document"
+
+    async def run(self, image_bytes: bytes, context: dict) -> CheckResult:
+        return await asyncio.to_thread(self._run_sync, image_bytes, context)
+
+    def _run_sync(self, image_bytes: bytes, context: dict) -> CheckResult:
+        try:
+            import pytesseract
+            from PIL import Image
+        except ImportError as e:
+            return CheckResult(check=self.check_id, passed=True, confidence=0.0, skipped=True, error=str(e))
+
+        try:
+            image = Image.open(io.BytesIO(image_bytes))
+            text = pytesseract.image_to_string(image)
+        except Exception as e:
+            return CheckResult(check=self.check_id, passed=True, confidence=0.0, skipped=True, error=str(e))
+
+        text_lower = text.lower()
+        schemas = _get_schemas()
+
+        doc_type = self._detect_doc_type(text_lower, schemas.get("detection_keywords", {}))
+
+        if doc_type is None:
+            return CheckResult(check=self.check_id, passed=True, confidence=0.0, skipped=True)
+
+        context["doc_type"] = doc_type
+
+        if not context.get("country"):
+            detected = self._detect_country(text_lower)
+            if detected:
+                context["country"] = detected
+
+        # Detection complete — Gemini validates the document content
+        return CheckResult(
+            check=self.check_id,
+            passed=True,
+            confidence=0.0,
+            skipped=True,
+            signals={"doc_type": doc_type, "country": context.get("country")},
+            normalized_signals=NormalizedSignals(
+                category="document_authenticity",
+                confidence=0.0,
+                indicators=["DOCUMENT_DETECTED"],
+                document_type=doc_type,
+                country_code=context.get("country"),
+            ),
+        )
+
+    def _detect_doc_type(self, text_lower: str, keywords: dict) -> str | None:
+        for doc_type, kws in keywords.items():
+            if any(kw.lower() in text_lower for kw in kws):
+                return doc_type
+        return None
+
+    def _detect_country(self, text_lower: str) -> str | None:
+        _COUNTRY_SIGNALS = {
+            "DE": ["bundesrepublik deutschland", "germany", "deutschland"],
+            "KE": ["republic of kenya", "kenya"],
+            "NG": ["federal republic of nigeria", "nigeria"],
+        }
+        for country, signals in _COUNTRY_SIGNALS.items():
+            if any(s in text_lower for s in signals):
+                return country
+        return None

--- a/tools/fake_image_detector/checks/reverse_image_check.py
+++ b/tools/fake_image_detector/checks/reverse_image_check.py
@@ -1,0 +1,216 @@
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from urllib.parse import urlparse
+
+from tools.fake_image_detector.checks.base_check import BaseCheck, CheckContext
+from tools.fake_image_detector.models import CheckResult, NormalizedSignals
+
+
+@dataclass
+class _VisionResult:
+    exact_count: int = 0
+    similar_count: int = 0
+    top_urls: list[str] | None = None
+
+
+class ReverseImageCheck(BaseCheck):
+    check_id = "reverse_image"
+
+    def __init__(self, params: dict | None = None) -> None:
+        p = params or {}
+        self._timeout_seconds = float(p.get("timeout_seconds", 10.0))
+        self._max_retries = max(1, int(p.get("max_retries", 2)))
+        self._stock_domains = {d.lower() for d in p.get("stock_domains", [
+            "shutterstock.com",
+            "gettyimages.com",
+            "istockphoto.com",
+            "adobe.com",
+            "alamy.com",
+            "pexels.com",
+            "unsplash.com",
+            "dreamstime.com",
+        ])}
+        self._social_domains = {d.lower() for d in p.get("social_domains", [
+            "facebook.com",
+            "instagram.com",
+            "x.com",
+            "twitter.com",
+            "tiktok.com",
+            "linkedin.com",
+            "reddit.com",
+        ])}
+        self._news_domains = {d.lower() for d in p.get("news_domains", [
+            "cnn.com",
+            "bbc.com",
+            "reuters.com",
+            "apnews.com",
+            "nytimes.com",
+            "theguardian.com",
+        ])}
+
+    async def run(self, image_bytes: bytes, context: CheckContext) -> CheckResult:
+        try:
+            return await asyncio.wait_for(
+                asyncio.to_thread(self._run_sync, image_bytes),
+                timeout=self._timeout_seconds,
+            )
+        except TimeoutError:
+            return CheckResult(
+                check=self.check_id,
+                passed=True,
+                skipped=True,
+                confidence=0.0,
+                flags=["REVERSE_SEARCH_UNAVAILABLE", "CHECK_TIMEOUT"],
+                signals={"error": "Google Vision reverse search timed out"},
+                normalized_signals=NormalizedSignals(
+                    category="staging",
+                    confidence=0.0,
+                    indicators=["REVERSE_SEARCH_UNAVAILABLE", "CHECK_TIMEOUT"],
+                    staging_score=0.21,
+                ),
+            )
+
+    def _run_sync(self, image_bytes: bytes) -> CheckResult:
+        errors: list[str] = []
+        for _ in range(self._max_retries):
+            try:
+                result = self._search_vision(image_bytes)
+                return self._score_result(result)
+            except Exception as e:
+                errors.append(str(e))
+                continue
+
+        return CheckResult(
+            check=self.check_id,
+            passed=True,
+            skipped=True,
+            confidence=0.0,
+            flags=["REVERSE_SEARCH_UNAVAILABLE"],
+            signals={"errors": errors},
+            normalized_signals=NormalizedSignals(
+                category="staging",
+                confidence=0.0,
+                indicators=["REVERSE_SEARCH_UNAVAILABLE"],
+                staging_score=0.21,
+            ),
+        )
+
+    def _search_vision(self, image_bytes: bytes) -> _VisionResult:
+        try:
+            from google.cloud import vision
+        except ImportError as e:
+            raise RuntimeError(str(e)) from e
+
+        client = vision.ImageAnnotatorClient()
+        image = vision.Image(content=image_bytes)
+        response = client.web_detection(image=image)
+
+        if response.error and response.error.message:
+            raise RuntimeError(response.error.message)
+
+        web = response.web_detection
+        full = list(getattr(web, "full_matching_images", []) or [])
+        partial = list(getattr(web, "partial_matching_images", []) or [])
+        pages = list(getattr(web, "pages_with_matching_images", []) or [])
+
+        urls: list[str] = []
+        for item in full:
+            url = getattr(item, "url", None)
+            if url:
+                urls.append(url)
+        for item in partial:
+            url = getattr(item, "url", None)
+            if url:
+                urls.append(url)
+        for page in pages:
+            page_url = getattr(page, "url", None) or getattr(page, "page_url", None)
+            if page_url:
+                urls.append(page_url)
+
+        return _VisionResult(
+            exact_count=len(full),
+            similar_count=len(partial),
+            top_urls=urls[:20],
+        )
+
+    def _score_result(self, result: _VisionResult) -> CheckResult:
+        urls = result.top_urls or []
+        domains = [self._domain_from_url(u) for u in urls if u]
+        has_stock = any(self._is_domain_in(d, self._stock_domains) for d in domains)
+        has_social = any(self._is_domain_in(d, self._social_domains) for d in domains)
+        has_news = any(self._is_domain_in(d, self._news_domains) for d in domains)
+        has_gov = any(d.endswith(".gov") for d in domains if d)
+
+        total_matches = max(0, int(result.exact_count) + int(result.similar_count))
+        confidence = round(min(1.0, 0.55 + 0.08 * min(total_matches, 5)), 3)
+
+        if total_matches <= 0:
+            return CheckResult(
+                check=self.check_id,
+                passed=True,
+                fake_score=0.0,
+                confidence=0.7,
+                flags=["NO_MATCH"],
+                signals={"provider": "google_vision_web_detection", "match_count": 0},
+                normalized_signals=NormalizedSignals(
+                    category="staging",
+                    confidence=0.7,
+                    indicators=["NO_MATCH"],
+                    staging_score=0.0,
+                ),
+            )
+
+        if has_stock:
+            return self._fail_result(result, confidence, 1.0, "STOCK_PHOTO_REUSE", domains)
+        if has_gov:
+            return self._fail_result(result, confidence, 0.8, "OFFICIAL_DOCUMENT_REUSE", domains)
+        if has_social or has_news:
+            return self._fail_result(result, confidence, 0.9, "FOUND_ONLINE_REUSE", domains)
+        if result.exact_count > 0:
+            return self._fail_result(result, confidence, 0.75, "FOUND_ONLINE", domains)
+
+        return self._fail_result(result, confidence, 0.4, "SIMILAR_IMAGE_FOUND", domains)
+
+    def _fail_result(
+        self,
+        result: _VisionResult,
+        confidence: float,
+        fake_score: float,
+        flag: str,
+        domains: list[str],
+    ) -> CheckResult:
+        return CheckResult(
+            check=self.check_id,
+            passed=False,
+            fake_score=round(fake_score, 3),
+            confidence=confidence,
+            flags=[flag],
+            signals={
+                "provider": "google_vision_web_detection",
+                "exact_count": result.exact_count,
+                "similar_count": result.similar_count,
+                "domains": domains[:10],
+            },
+            normalized_signals=NormalizedSignals(
+                category="staging",
+                confidence=confidence,
+                indicators=[flag],
+                staging_score=round(fake_score, 3),
+            ),
+        )
+
+    def _domain_from_url(self, value: str) -> str:
+        try:
+            netloc = urlparse(value).netloc.lower()
+        except Exception:
+            return ""
+        if netloc.startswith("www."):
+            return netloc[4:]
+        return netloc
+
+    def _is_domain_in(self, domain: str, domain_set: set[str]) -> bool:
+        if not domain:
+            return False
+        return any(domain == d or domain.endswith(f".{d}") for d in domain_set)

--- a/tools/fake_image_detector/checks/reverse_image_check.py
+++ b/tools/fake_image_detector/checks/reverse_image_check.py
@@ -5,7 +5,19 @@ from dataclasses import dataclass
 from urllib.parse import urlparse
 
 from tools.fake_image_detector.checks.base_check import BaseCheck, CheckContext
-from tools.fake_image_detector.models import CheckResult, NormalizedSignals
+from tools.fake_image_detector.models import (
+    CheckResult,
+    GL9_FLAG_FOUND_ONLINE,
+    GL9_FLAG_POSSIBLE_STOCK,
+    GL9_HARD_ESCALATION_FLAGS,
+    NormalizedSignals,
+)
+
+_FLAG_ALIASES = {
+    "FOUND_ONLINE_REUSE": GL9_FLAG_FOUND_ONLINE,
+    "STOCK_PHOTO_REUSE": GL9_FLAG_POSSIBLE_STOCK,
+    "STOCK_PHOTO_INDICATORS": GL9_FLAG_POSSIBLE_STOCK,
+}
 
 
 @dataclass
@@ -163,30 +175,40 @@ class ReverseImageCheck(BaseCheck):
             )
 
         if has_stock:
-            return self._fail_result(result, confidence, 1.0, "STOCK_PHOTO_REUSE", domains)
+            return self._fail_result(result, confidence, 1.0, [GL9_FLAG_POSSIBLE_STOCK], domains)
         if has_gov:
-            return self._fail_result(result, confidence, 0.8, "OFFICIAL_DOCUMENT_REUSE", domains)
+            return self._fail_result(result, confidence, 0.8, ["OFFICIAL_DOCUMENT_REUSE"], domains)
         if has_social or has_news:
-            return self._fail_result(result, confidence, 0.9, "FOUND_ONLINE_REUSE", domains)
+            return self._fail_result(result, confidence, 0.9, [GL9_FLAG_FOUND_ONLINE], domains)
         if result.exact_count > 0:
-            return self._fail_result(result, confidence, 0.75, "FOUND_ONLINE", domains)
+            return self._fail_result(result, confidence, 0.75, [GL9_FLAG_FOUND_ONLINE], domains)
 
-        return self._fail_result(result, confidence, 0.4, "SIMILAR_IMAGE_FOUND", domains)
+        return self._fail_result(result, confidence, 0.4, ["SIMILAR_IMAGE_FOUND"], domains)
+
+    def _normalize_flags(self, flags: list[str]) -> list[str]:
+        canonical: list[str] = []
+        for flag in flags:
+            normalized = _FLAG_ALIASES.get(flag, flag)
+            if normalized not in canonical:
+                canonical.append(normalized)
+        return canonical
 
     def _fail_result(
         self,
         result: _VisionResult,
         confidence: float,
         fake_score: float,
-        flag: str,
+        flags: list[str],
         domains: list[str],
     ) -> CheckResult:
+        normalized_flags = self._normalize_flags(flags)
+        escalation_reasons = [f"{flag} detected by reverse_image check" for flag in normalized_flags if flag in GL9_HARD_ESCALATION_FLAGS]
         return CheckResult(
             check=self.check_id,
             passed=False,
             fake_score=round(fake_score, 3),
             confidence=confidence,
-            flags=[flag],
+            flags=normalized_flags,
             signals={
                 "provider": "google_vision_web_detection",
                 "exact_count": result.exact_count,
@@ -196,9 +218,11 @@ class ReverseImageCheck(BaseCheck):
             normalized_signals=NormalizedSignals(
                 category="staging",
                 confidence=confidence,
-                indicators=[flag],
+                indicators=normalized_flags,
                 staging_score=round(fake_score, 3),
             ),
+            human_escalate=bool(escalation_reasons),
+            escalation_reasons=escalation_reasons,
         )
 
     def _domain_from_url(self, value: str) -> str:

--- a/tools/fake_image_detector/models.py
+++ b/tools/fake_image_detector/models.py
@@ -16,6 +16,17 @@ class Escalation(str, Enum):
     AUTO_REJECT = "AUTO_REJECT"
 
 
+GL9_FLAG_FOUND_ONLINE = "FOUND_ONLINE"
+GL9_FLAG_POSSIBLE_STOCK = "POSSIBLE_STOCK"
+GL9_FLAG_EDITING_ARTIFACTS = "EDITING_ARTIFACTS"
+GL9_FLAG_AGE_INCONSISTENCY = "AGE_INCONSISTENCY"
+
+GL9_HARD_ESCALATION_FLAGS = {
+    GL9_FLAG_FOUND_ONLINE,
+    GL9_FLAG_POSSIBLE_STOCK,
+}
+
+
 class NormalizedSignals(BaseModel):
     category: str | None = None
     confidence: float | None = Field(default=None, ge=0.0, le=1.0)
@@ -37,6 +48,8 @@ class CheckResult(BaseModel):
     normalized_signals: NormalizedSignals | None = None
     skipped: bool = False
     error: str | None = None
+    human_escalate: bool = False
+    escalation_reasons: list[str] = Field(default_factory=list)
 
 
 class ToolResult(BaseModel):

--- a/tools/fake_image_detector/pipeline.py
+++ b/tools/fake_image_detector/pipeline.py
@@ -15,7 +15,13 @@ except ImportError:  # pragma: no cover - optional dependency
 
 from tools.fake_image_detector.checks.base_check import BaseCheck
 from tools.fake_image_detector.config_loader import PipelineConfig, load_pipeline_config
-from tools.fake_image_detector.models import CheckResult, Escalation, ToolResult, Verdict
+from tools.fake_image_detector.models import (
+    CheckResult,
+    Escalation,
+    GL9_HARD_ESCALATION_FLAGS,
+    ToolResult,
+    Verdict,
+)
 
 InputType = Literal["document", "face", "unknown"]
 
@@ -108,6 +114,19 @@ class FakeImageDetectorPipeline:
 
             results.append(result)
 
+            if self._should_force_human_escalation(result):
+                return ToolResult(
+                    verdict=Verdict.FLAG,
+                    risk_score=round(max(self._config.clear_pass, result.fake_score), 4),
+                    escalation=Escalation.HUMAN_REVIEW,
+                    checks=results,
+                    early_exit=True,
+                    early_exit_reason=(
+                        f"{check_cfg.id} triggered hard escalation: "
+                        f"{self._hard_escalation_flags(result.flags)}"
+                    ),
+                )
+
             if check_cfg.early_exit_on_fail and not result.passed and not result.skipped:
                 risk_score = result.fake_score
                 verdict, escalation = self._classify(risk_score)
@@ -165,6 +184,19 @@ class FakeImageDetectorPipeline:
             )
 
         final_risk = result.fake_score
+        if self._should_force_human_escalation(result):
+            return ToolResult(
+                verdict=Verdict.FLAG,
+                risk_score=round(max(self._config.clear_pass, final_risk), 4),
+                escalation=Escalation.HUMAN_REVIEW,
+                checks=stage1.checks + [result],
+                early_exit=True,
+                early_exit_reason=(
+                    "gemini_vision triggered hard escalation: "
+                    f"{self._hard_escalation_flags(result.flags)}"
+                ),
+            )
+
         verdict, escalation = self._classify(final_risk)
 
         return ToolResult(
@@ -185,6 +217,14 @@ class FakeImageDetectorPipeline:
             # Fail-safe: checks ran but produced no usable confidence → force human review band.
             return round(min(self._config.clear_fail, self._config.clear_pass + 0.01), 4)
         return round(sum(r.fake_score * r.confidence for r in active) / total_weight, 4)
+
+    def _hard_escalation_flags(self, flags: list[str]) -> list[str]:
+        return [flag for flag in flags if flag in GL9_HARD_ESCALATION_FLAGS]
+
+    def _should_force_human_escalation(self, result: CheckResult) -> bool:
+        if result.human_escalate:
+            return True
+        return bool(self._hard_escalation_flags(result.flags))
 
     def _classify(self, risk_score: float) -> tuple[Verdict, Escalation]:
         if risk_score >= self._config.clear_fail:


### PR DESCRIPTION
## Summary

- **GeminiVisionCheck** — Vertex AI vision analysis for synthetic and document fraud; structured JSON prompt (no final verdict); fail-closed on parse errors and API failures
- **GeminiExtractCheck** — field extraction per document type; writes `extracted_fields` into context for the Gemini vision prompt
- **ReverseImageCheck** — Google Vision web detection; classifies stock/social/news/gov domains
- **CNNDeepfakeCheck** — ONNX ViT model inference; skips gracefully when model not present
- **MRZCheck** — passporteye MRZ parsing; only passes on `valid_score=100`
- **OCRDocumentCheck** — pytesseract document type detection; sets `doc_type` and `country` in context for downstream Gemini checks

## Design decisions

**Hard escalation** — `FOUND_ONLINE` and `POSSIBLE_STOCK` bypass score-based routing and force immediate human review regardless of the weighted risk score. These signals indicate confirmed reuse of a known image, which no confidence weighting should override.

**Flag normalization** — legacy flag names (`EDITING_DETECTED`, `STOCK_PHOTO_INDICATORS`) are mapped to canonical GL9 constants at the check boundary so the pipeline and downstream consumers always see a consistent vocabulary.

**Input type auto-detection** — when `input_type` is not passed explicitly, the pipeline uses TIFF magic bytes and pytesseract text density to classify document vs face.

## Caveats

- Google Vision API (reverse image search) requires billing enabled on the GCP project
- Vertex AI (Gemini vision + extract) requires billing enabled on the GCP project
- CNN model (~83MB ONNX) must be downloaded separately:
  `python scripts/fake_image_detector/download_model.py --variant int8`

Both APIs degrade gracefully — reverse image skips, Gemini fails closed — so the pipeline produces a result even without billing enabled.

## Test plan

- [x] `pytest -q tests/unit/tools/fake_image_detector` — 96 passed
- [x] All external APIs mocked (`google.genai`, `google.cloud.vision`, `passporteye`, `pytesseract`)
- [x] Manual run: `python scripts/fake_image_detector/test_checks.py <image> --type face`