### PR TITLE
POC-1 — Foundation: Data Models, Pipeline & Input Layer

### DIFF
--- a/app/core/pii.py
+++ b/app/core/pii.py
@@ -6,14 +6,13 @@ import json
 import logging
 import time
 from copy import deepcopy
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from datetime import date, datetime, timezone
 from hashlib import sha256
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 import yaml
-from dataclasses import replace
 
 if TYPE_CHECKING:
     from app.core.envelope import CanonicalMessage

--- a/poc/__init__.py
+++ b/poc/__init__.py
@@ -1,0 +1,1 @@
+"""POC-1: Foundation — data models, pipeline skeleton, and input layer."""

--- a/poc/api.py
+++ b/poc/api.py
@@ -1,0 +1,61 @@
+"""POC-1 FastAPI endpoint — POST /score.
+
+Accepts multipart image + form fields, constructs a Submission, runs the
+pipeline, and returns a ReliabilityResult as JSON.
+
+Run locally:
+    uvicorn poc.api:app --reload
+"""
+
+from __future__ import annotations
+
+import json
+
+from fastapi import FastAPI, File, Form, HTTPException, UploadFile
+
+from poc.models import ReliabilityResult, Submission
+from poc.pipeline import run_pipeline
+
+app = FastAPI(
+    title="B2 POC-1 — Reliability Scorer",
+    description="Scores the reliability of a death certificate submission.",
+    version="0.1.0",
+)
+
+
+@app.post("/score", response_model=ReliabilityResult)
+async def score(
+    image: UploadFile = File(..., description="Certificate image (PNG/JPEG/WEBP)."),
+    narrative: str = Form(..., description="Free-text narrative from the claimant."),
+    case_fields: str = Form(
+        default="{}",
+        description="JSON object of structured case metadata.",
+    ),
+) -> ReliabilityResult:
+    """Score the reliability of a submitted death certificate.
+
+    Returns a ReliabilityResult with score (1–100), band, sub-scores,
+    flags, justification, and extracted certificate fields.
+    """
+    image_bytes = await image.read()
+    if not image_bytes:
+        raise HTTPException(status_code=422, detail="image must not be empty")
+
+    try:
+        fields = json.loads(case_fields)
+    except json.JSONDecodeError as exc:
+        raise HTTPException(
+            status_code=422,
+            detail=f"case_fields is not valid JSON: {exc}",
+        ) from exc
+
+    try:
+        submission = Submission(
+            image=image_bytes,
+            narrative=narrative,
+            case_fields=fields,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+
+    return await run_pipeline(submission)

--- a/poc/cli.py
+++ b/poc/cli.py
@@ -1,0 +1,137 @@
+"""POC-1 CLI — python -m poc.cli score.
+
+Usage (local file):
+    python -m poc.cli score \\
+        --image path/to/cert.png \\
+        --narrative "My father passed away on March 3rd." \\
+        --fields '{"case_id": "ABC-123"}'
+
+Usage (GCS URI):
+    python -m poc.cli score \\
+        --image gs://your-bucket/cert.jpg \\
+        --narrative "My father passed away on March 3rd." \\
+        --fields '{"case_id": "ABC-123"}'
+
+Accepts either a local file path or a GCS URI (gs://bucket/blob).
+GCS download happens at the boundary — Submission always receives bytes.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+from pathlib import Path
+
+
+async def _resolve_image(image_arg: str) -> bytes:
+    """Return image bytes from either a local path or a GCS URI.
+
+    GCS URIs (gs://bucket-name/path/to/blob) are downloaded using the
+    google-cloud-storage client. Local paths are read from disk.
+    """
+    if image_arg.startswith("gs://"):
+        try:
+            from google.cloud import storage
+        except ImportError:
+            print(
+                "error: google-cloud-storage is required for GCS URIs. "
+                "Install it with: pip install google-cloud-storage",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+
+        # Parse gs://bucket-name/path/to/blob
+        without_scheme = image_arg[len("gs://"):]
+        bucket_name, _, blob_path = without_scheme.partition("/")
+
+        if not bucket_name or not blob_path:
+            print(
+                f"error: invalid GCS URI '{image_arg}'. "
+                "Expected format: gs://bucket-name/path/to/blob",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+
+        try:
+            client = storage.Client()
+            bucket = client.bucket(bucket_name)
+            return bucket.blob(blob_path).download_as_bytes()
+        except Exception as exc:
+            print(f"error: failed to download from GCS: {exc}", file=sys.stderr)
+            sys.exit(1)
+
+    # Local file path
+    path = Path(image_arg)
+    if not path.exists():
+        print(f"error: image not found at '{image_arg}'", file=sys.stderr)
+        sys.exit(1)
+    return path.read_bytes()
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="poc.cli",
+        description="B2 POC-1 reliability scorer CLI.",
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    score_parser = sub.add_parser("score", help="Score a certificate submission.")
+    score_parser.add_argument(
+        "--image",
+        required=True,
+        metavar="PATH_OR_GCS_URI",
+        help="Local path or GCS URI (gs://bucket/blob) to the certificate image.",
+    )
+    score_parser.add_argument(
+        "--narrative",
+        required=True,
+        metavar="TEXT",
+        help="Free-text narrative from the claimant.",
+    )
+    score_parser.add_argument(
+        "--fields",
+        default="{}",
+        metavar="JSON",
+        help="JSON object of structured case metadata (default: {}).",
+    )
+    return parser
+
+
+async def _run_score(image_path: str, narrative: str, fields_json: str) -> None:
+    from poc.models import Submission
+    from poc.pipeline import run_pipeline
+
+    try:
+        case_fields = json.loads(fields_json)
+    except json.JSONDecodeError as exc:
+        print(f"error: --fields is not valid JSON: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    image_bytes = await _resolve_image(image_path)
+
+    try:
+        submission = Submission(
+            image=image_bytes,
+            narrative=narrative,
+            case_fields=case_fields,
+        )
+    except ValueError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    result = await run_pipeline(submission)
+    print(result.model_dump_json(indent=2))
+
+
+def main() -> None:
+    parser = _build_parser()
+    args = parser.parse_args()
+
+    if args.command == "score":
+        asyncio.run(_run_score(args.image, args.narrative, args.fields))
+
+
+if __name__ == "__main__":
+    main()

--- a/poc/models.py
+++ b/poc/models.py
@@ -1,0 +1,150 @@
+"""POC-1 data models — Submission, signal types, ReliabilityResult.
+
+All models are Pydantic BaseModel so they serialise to JSON natively and
+integrate with FastAPI response_model without extra boilerplate.
+
+Design decisions (locked via grill-me session):
+- Pydantic throughout (matches fake_image_detector/models.py)
+- Submission.image: bytes — I/O conversion happens at the boundary (API/CLI)
+- case_fields: dict[str, Any] — free-form, scorer defines structure later
+- AuthenticitySignal wraps ToolResult directly (no flattening)
+- extracted_fields: dict[str, Any] — not typed until scorer consumes it
+- Band: single four-value enum; "escalate" overrides quality bands
+- sub_scores: 0.0–1.0 floats; final score: int 1–100
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import Any
+
+from pydantic import BaseModel, Field, field_validator
+
+from tools.fake_image_detector.models import ToolResult
+
+
+# ---------------------------------------------------------------------------
+# Band enum
+# ---------------------------------------------------------------------------
+
+class Band(str, Enum):
+    """Customer-facing reliability band.
+
+    HIGH     — score 75–100: strong evidence, proceed with confidence.
+    MEDIUM   — score 50–74: reasonable evidence, minor gaps present.
+    LOW      — score 25–49: significant gaps, manual follow-up advised.
+    ESCALATE — score 0–24 OR hard flag from authenticity stage: requires
+               immediate human review regardless of numeric score.
+    """
+
+    HIGH     = "high"
+    MEDIUM   = "medium"
+    LOW      = "low"
+    ESCALATE = "escalate"
+
+
+# ---------------------------------------------------------------------------
+# Submission — the input contract
+# ---------------------------------------------------------------------------
+
+class Submission(BaseModel):
+    """Incoming case submission.
+
+    narrative is a first-class field (not buried in case_fields) because it
+    is the primary claim being cross-referenced against the certificate.
+    image is always bytes — conversion from Path or upload happens at the
+    API/CLI boundary before Submission is constructed.
+    """
+
+    image: bytes
+    narrative: str
+    case_fields: dict[str, Any] = Field(default_factory=dict)
+
+    @field_validator("narrative")
+    @classmethod
+    def narrative_must_not_be_blank(cls, v: str) -> str:
+        if not v.strip():
+            raise ValueError("narrative must not be blank")
+        return v
+
+    model_config = {"arbitrary_types_allowed": True}
+
+
+# ---------------------------------------------------------------------------
+# Signal types — one per pipeline stage
+# ---------------------------------------------------------------------------
+
+class DocumentSignal(BaseModel):
+    """Output of the document analysis stage.
+
+    Answers: can we read this document and what type is it?
+    Does NOT score fakeness — that is AuthenticitySignal's job.
+    """
+
+    legible: bool = False
+    document_type: str | None = None
+    page_count: int = 1
+    language_hint: str | None = None
+    notes: list[str] = Field(default_factory=list)
+    stage: str = "document_analysis"
+
+
+class AuthenticitySignal(BaseModel):
+    """Output of the authenticity stage.
+
+    Wraps ToolResult from the fake_image_detector pipeline directly.
+    POC-2 constructs this as AuthenticitySignal(result=tool_result).
+    """
+
+    result: ToolResult
+    stage: str = "authenticity"
+
+    model_config = {"arbitrary_types_allowed": True}
+
+
+class ConsistencySignal(BaseModel):
+    """Output of the narrative consistency stage.
+
+    Maps directly from analyze_death_certificate_consistency() output.
+    extracted_fields carries certificate data through to ReliabilityResult
+    where it is surfaced to the customer.
+
+    Note: POC-2 maps 'mismatches' → 'contradictions' when constructing this.
+    """
+
+    consistency_score: float = Field(default=0.0, ge=0.0, le=1.0)
+    consistency_label: str = "unknown"
+    confidence: float = Field(default=0.0, ge=0.0, le=1.0)
+    extracted_fields: dict[str, Any] = Field(default_factory=dict)
+    matches: list[str] = Field(default_factory=list)
+    contradictions: list[str] = Field(default_factory=list)
+    uncertain_points: list[str] = Field(default_factory=list)
+    summary: str = ""
+    stage: str = "consistency"
+
+
+# ---------------------------------------------------------------------------
+# ReliabilityResult — the output contract
+# ---------------------------------------------------------------------------
+
+class ReliabilityResult(BaseModel):
+    """Final customer-facing reliability verdict.
+
+    score        — 1–100 integer computed from weighted sub_scores.
+    band         — customer-facing quality band (see Band enum).
+    sub_scores   — per-stage scores (0.0–1.0); keys: document, authenticity,
+                   consistency.
+    weights      — per-stage weights summing to 1.0.
+    flags        — list of named concerns, e.g. ["HARD_ESCALATION"].
+    justification — human-readable explanation of the verdict.
+    extracted_fields — certificate data from ConsistencySignal, surfaced
+                       directly to the customer (POC-2 populates this).
+    """
+
+    score: int = Field(ge=1, le=100)
+    band: Band
+    sub_scores: dict[str, float] = Field(default_factory=dict)
+    weights: dict[str, float] = Field(default_factory=dict)
+    flags: list[str] = Field(default_factory=list)
+    justification: str
+    extracted_fields: dict[str, Any] = Field(default_factory=dict)

--- a/poc/pipeline.py
+++ b/poc/pipeline.py
@@ -1,0 +1,161 @@
+"""POC-1 pipeline — run_pipeline() with six stubbed stages.
+
+Stage order: intake → document analysis → authenticity → consistency →
+             scorer → result
+
+All stage functions are async from the start so POC-2 can drop in real
+implementations (the fake_image_detector is async) without changing
+run_pipeline's signature.
+
+Stub default values produce:
+  sub_scores  = {document: 1.0, authenticity: 0.9, consistency: 0.8}
+  weights     = {document: 0.2, authenticity: 0.4, consistency: 0.4}
+  weighted    = 1.0×0.2 + 0.9×0.4 + 0.8×0.4 = 0.88
+  score       = 88
+  band        = Band.HIGH
+
+Hard escalation (AuthenticitySignal.result.escalation == HUMAN_REVIEW or
+AUTO_REJECT) forces Band.ESCALATE and appends "HARD_ESCALATION" to flags,
+overriding the numeric score band.
+"""
+
+from __future__ import annotations
+
+from tools.fake_image_detector.models import Escalation, ToolResult, Verdict
+
+from poc.models import (
+    AuthenticitySignal,
+    Band,
+    ConsistencySignal,
+    DocumentSignal,
+    ReliabilityResult,
+    Submission,
+)
+
+# ---------------------------------------------------------------------------
+# Default stub values
+# ---------------------------------------------------------------------------
+
+_DEFAULT_TOOL_RESULT = ToolResult(
+    verdict=Verdict.PASS,
+    risk_score=0.1,
+    escalation=Escalation.AUTO_ACCEPT,
+    checks=[],
+)
+
+_STAGE_WEIGHTS: dict[str, float] = {
+    "document":     0.2,
+    "authenticity": 0.4,
+    "consistency":  0.4,
+}
+
+
+# ---------------------------------------------------------------------------
+# Stage stubs — POC-2 replaces each body with real implementation
+# ---------------------------------------------------------------------------
+
+async def _stage_document(submission: Submission) -> DocumentSignal:
+    """Stub: assumes document is legible and typed as death_certificate."""
+    return DocumentSignal(
+        legible=True,
+        document_type="death_certificate",
+    )
+
+
+async def _stage_authenticity(submission: Submission) -> AuthenticitySignal:
+    """Stub: returns a clean PASS from the fake_image_detector defaults."""
+    return AuthenticitySignal(result=_DEFAULT_TOOL_RESULT)
+
+
+async def _stage_consistency(submission: Submission) -> ConsistencySignal:
+    """Stub: returns high consistency with empty extracted fields."""
+    return ConsistencySignal(
+        consistency_score=0.8,
+        consistency_label="high",
+        confidence=0.75,
+        summary="Stub pipeline: no LLM analysis performed.",
+    )
+
+
+async def _stage_score(
+    doc: DocumentSignal,
+    auth: AuthenticitySignal,
+    con: ConsistencySignal,
+) -> ReliabilityResult:
+    """Compute ReliabilityResult from the three signal outputs.
+
+    Hard escalation from the authenticity stage overrides the numeric band
+    regardless of score — consistent with GL9_HARD_ESCALATION_FLAGS logic
+    already in the fake_image_detector pipeline.
+    """
+    # Derive per-stage scores from signal outputs
+    doc_score  = 1.0 if doc.legible else 0.3
+    auth_score = round(1.0 - auth.result.risk_score, 3)
+    con_score  = con.consistency_score
+
+    sub_scores: dict[str, float] = {
+        "document":     round(doc_score, 3),
+        "authenticity": auth_score,
+        "consistency":  round(con_score, 3),
+    }
+
+    weighted = sum(sub_scores[k] * _STAGE_WEIGHTS[k] for k in _STAGE_WEIGHTS)
+    raw_score = max(1, min(100, round(weighted * 100)))
+
+    flags: list[str] = []
+
+    # Hard escalation overrides band — mirrors Escalation.HUMAN_REVIEW /
+    # AUTO_REJECT semantics from the fake_image_detector pipeline.
+    hard_escalation = auth.result.escalation in (
+        Escalation.HUMAN_REVIEW,
+        Escalation.AUTO_REJECT,
+    )
+
+    if hard_escalation:
+        band = Band.ESCALATE
+        flags.append("HARD_ESCALATION")
+    elif raw_score >= 75:
+        band = Band.HIGH
+    elif raw_score >= 50:
+        band = Band.MEDIUM
+    elif raw_score >= 25:
+        band = Band.LOW
+    else:
+        band = Band.ESCALATE
+
+    justification = (
+        f"document={'legible' if doc.legible else 'illegible'} "
+        f"(type={doc.document_type or 'unknown'}), "
+        f"authenticity={auth.result.verdict.value} "
+        f"(risk={auth.result.risk_score:.2f}), "
+        f"consistency={con.consistency_label} "
+        f"(score={con.consistency_score:.2f})"
+    )
+
+    return ReliabilityResult(
+        score=raw_score,
+        band=band,
+        sub_scores=sub_scores,
+        weights=dict(_STAGE_WEIGHTS),
+        flags=flags,
+        justification=justification,
+        extracted_fields=con.extracted_fields,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+async def run_pipeline(submission: Submission) -> ReliabilityResult:
+    """Run the full reliability pipeline on a Submission.
+
+    Stages run sequentially: document → authenticity → consistency → score.
+    Each stage is async so POC-2 can wire in the real implementations
+    (fake_image_detector is async) without touching this function.
+    """
+    doc_signal  = await _stage_document(submission)
+    auth_signal = await _stage_authenticity(submission)
+    con_signal  = await _stage_consistency(submission)
+    result      = await _stage_score(doc_signal, auth_signal, con_signal)
+    return result

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,3 +26,8 @@ google-cloud-aiplatform>=1.50.0
 google-cloud-vision>=3.7.0
 httpx>=0.27.0
 onnxruntime>=1.18.0
+
+# POC-1: Foundation — data model, pipeline, input
+python-multipart>=0.0.9
+pytest-asyncio>=0.23.0
+google-cloud-storage>=2.0.0

--- a/tests/unit/poc/test_pipeline.py
+++ b/tests/unit/poc/test_pipeline.py
@@ -1,0 +1,477 @@
+"""POC-1 unit tests.
+
+Covers every acceptance criterion from the GitHub issue plus edge cases:
+
+1. All models are typed and constructable
+2. narrative is a first-class field with blank validation
+3. run_pipeline() runs end-to-end on stubs and returns valid ReliabilityResult
+4. band enum covers high, medium, low, escalate
+5. score is int in [1, 100]
+6. sub_scores has the three expected keys; weights sum to 1.0
+7. Hard escalation from authenticity stage forces Band.ESCALATE
+8. FastAPI POST /score accepts image + narrative + fields and returns JSON
+9. CLI argument parser is wired correctly (smoke test)
+
+POC-2 alignment checks:
+- AuthenticitySignal correctly wraps ToolResult from fake_image_detector
+- ConsistencySignal field names match the shape analyze_death_certificate_consistency returns
+- extracted_fields passes through from ConsistencySignal to ReliabilityResult
+"""
+
+from __future__ import annotations
+
+import io
+import json
+
+import pytest
+
+from poc.models import (
+    AuthenticitySignal,
+    Band,
+    ConsistencySignal,
+    DocumentSignal,
+    ReliabilityResult,
+    Submission,
+)
+from poc.pipeline import _stage_score, run_pipeline
+from tools.fake_image_detector.models import Escalation, ToolResult, Verdict
+
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
+
+FAKE_IMAGE = b"\x89PNG\r\n\x1a\n"  # minimal PNG magic bytes
+NARRATIVE  = "My father John Smith passed away on March 3rd, 2021 in Chicago."
+
+
+@pytest.fixture()
+def minimal_submission() -> Submission:
+    return Submission(image=FAKE_IMAGE, narrative=NARRATIVE)
+
+
+# ---------------------------------------------------------------------------
+# 1. Model construction
+# ---------------------------------------------------------------------------
+
+class TestModelConstruction:
+    def test_submission_constructs_with_required_fields(self) -> None:
+        s = Submission(image=FAKE_IMAGE, narrative=NARRATIVE)
+        assert s.image == FAKE_IMAGE
+        assert s.narrative == NARRATIVE
+        assert s.case_fields == {}
+
+    def test_submission_accepts_case_fields(self) -> None:
+        s = Submission(image=FAKE_IMAGE, narrative=NARRATIVE, case_fields={"case_id": "ABC-1"})
+        assert s.case_fields["case_id"] == "ABC-1"
+
+    def test_document_signal_defaults(self) -> None:
+        sig = DocumentSignal()
+        assert sig.legible is False
+        assert sig.document_type is None
+        assert sig.page_count == 1
+        assert sig.stage == "document_analysis"
+
+    def test_authenticity_signal_wraps_tool_result(self) -> None:
+        tr = ToolResult(verdict=Verdict.PASS, risk_score=0.1,
+                        escalation=Escalation.AUTO_ACCEPT, checks=[])
+        sig = AuthenticitySignal(result=tr)
+        assert sig.result.verdict == Verdict.PASS
+        assert sig.stage == "authenticity"
+
+    def test_consistency_signal_defaults(self) -> None:
+        sig = ConsistencySignal()
+        assert sig.consistency_score == 0.0
+        assert sig.extracted_fields == {}
+        assert sig.stage == "consistency"
+
+    def test_reliability_result_constructs(self) -> None:
+        r = ReliabilityResult(
+            score=88,
+            band=Band.HIGH,
+            sub_scores={"document": 1.0, "authenticity": 0.9, "consistency": 0.8},
+            weights={"document": 0.2, "authenticity": 0.4, "consistency": 0.4},
+            flags=[],
+            justification="test",
+        )
+        assert r.score == 88
+        assert r.band == Band.HIGH
+
+
+# ---------------------------------------------------------------------------
+# 2. Submission.narrative validation
+# ---------------------------------------------------------------------------
+
+class TestNarrativeValidation:
+    def test_blank_narrative_raises(self) -> None:
+        with pytest.raises(ValueError, match="narrative must not be blank"):
+            Submission(image=FAKE_IMAGE, narrative="")
+
+    def test_whitespace_only_narrative_raises(self) -> None:
+        with pytest.raises(ValueError, match="narrative must not be blank"):
+            Submission(image=FAKE_IMAGE, narrative="   \t\n  ")
+
+    def test_valid_narrative_is_accepted(self) -> None:
+        s = Submission(image=FAKE_IMAGE, narrative="valid")
+        assert s.narrative == "valid"
+
+
+# ---------------------------------------------------------------------------
+# 3. Band enum completeness
+# ---------------------------------------------------------------------------
+
+class TestBandEnum:
+    def test_band_covers_all_four_values(self) -> None:
+        values = {b.value for b in Band}
+        assert values == {"high", "medium", "low", "escalate"}
+
+    def test_band_is_string_enum(self) -> None:
+        assert Band.HIGH == "high"
+        assert Band.ESCALATE == "escalate"
+
+
+# ---------------------------------------------------------------------------
+# 4. run_pipeline end-to-end on stubs
+# ---------------------------------------------------------------------------
+
+class TestRunPipeline:
+    @pytest.mark.asyncio
+    async def test_returns_reliability_result(
+        self, minimal_submission: Submission
+    ) -> None:
+        result = await run_pipeline(minimal_submission)
+        assert isinstance(result, ReliabilityResult)
+
+    @pytest.mark.asyncio
+    async def test_score_is_int_in_range(
+        self, minimal_submission: Submission
+    ) -> None:
+        result = await run_pipeline(minimal_submission)
+        assert isinstance(result.score, int)
+        assert 1 <= result.score <= 100
+
+    @pytest.mark.asyncio
+    async def test_band_is_valid_enum_value(
+        self, minimal_submission: Submission
+    ) -> None:
+        result = await run_pipeline(minimal_submission)
+        assert result.band in list(Band)
+
+    @pytest.mark.asyncio
+    async def test_sub_scores_has_three_stage_keys(
+        self, minimal_submission: Submission
+    ) -> None:
+        result = await run_pipeline(minimal_submission)
+        assert set(result.sub_scores) == {"document", "authenticity", "consistency"}
+
+    @pytest.mark.asyncio
+    async def test_weights_sum_to_one(
+        self, minimal_submission: Submission
+    ) -> None:
+        result = await run_pipeline(minimal_submission)
+        assert abs(sum(result.weights.values()) - 1.0) < 0.001
+
+    @pytest.mark.asyncio
+    async def test_justification_is_non_empty_string(
+        self, minimal_submission: Submission
+    ) -> None:
+        result = await run_pipeline(minimal_submission)
+        assert isinstance(result.justification, str)
+        assert len(result.justification) > 0
+
+    @pytest.mark.asyncio
+    async def test_extracted_fields_is_dict(
+        self, minimal_submission: Submission
+    ) -> None:
+        result = await run_pipeline(minimal_submission)
+        assert isinstance(result.extracted_fields, dict)
+
+    @pytest.mark.asyncio
+    async def test_default_stubs_produce_high_band(
+        self, minimal_submission: Submission
+    ) -> None:
+        # Stub defaults: doc=1.0, auth=0.9, con=0.8
+        # weighted = 1.0×0.2 + 0.9×0.4 + 0.8×0.4 = 0.88 → score=88 → HIGH
+        result = await run_pipeline(minimal_submission)
+        assert result.score == 88
+        assert result.band == Band.HIGH
+
+
+# ---------------------------------------------------------------------------
+# 5. Scorer — hard escalation overrides band
+# ---------------------------------------------------------------------------
+
+class TestScorerEscalation:
+    @pytest.mark.asyncio
+    async def test_human_review_forces_escalate_band(self) -> None:
+        doc  = DocumentSignal(legible=True, document_type="death_certificate")
+        auth = AuthenticitySignal(
+            result=ToolResult(
+                verdict=Verdict.FLAG,
+                risk_score=0.9,
+                escalation=Escalation.HUMAN_REVIEW,
+                checks=[],
+            )
+        )
+        con  = ConsistencySignal(consistency_score=0.8, consistency_label="high")
+
+        result = await _stage_score(doc, auth, con)
+
+        assert result.band == Band.ESCALATE
+        assert "HARD_ESCALATION" in result.flags
+
+    @pytest.mark.asyncio
+    async def test_auto_reject_forces_escalate_band(self) -> None:
+        doc  = DocumentSignal(legible=True)
+        auth = AuthenticitySignal(
+            result=ToolResult(
+                verdict=Verdict.REJECT,
+                risk_score=1.0,
+                escalation=Escalation.AUTO_REJECT,
+                checks=[],
+            )
+        )
+        con  = ConsistencySignal(consistency_score=0.9, consistency_label="high")
+
+        result = await _stage_score(doc, auth, con)
+
+        assert result.band == Band.ESCALATE
+        assert "HARD_ESCALATION" in result.flags
+
+    @pytest.mark.asyncio
+    async def test_low_scores_produce_low_band(self) -> None:
+        doc  = DocumentSignal(legible=False)            # doc_score = 0.3
+        auth = AuthenticitySignal(
+            result=ToolResult(
+                verdict=Verdict.FLAG,
+                risk_score=0.6,                         # auth_score = 0.4
+                escalation=Escalation.AUTO_ACCEPT,
+                checks=[],
+            )
+        )
+        con  = ConsistencySignal(consistency_score=0.2) # con_score = 0.2
+
+        result = await _stage_score(doc, auth, con)
+
+        # weighted = 0.3×0.2 + 0.4×0.4 + 0.2×0.4 = 0.06+0.16+0.08 = 0.30
+        # score = 30 → LOW
+        assert result.band == Band.LOW
+        assert result.score == 30
+
+    @pytest.mark.asyncio
+    async def test_very_low_scores_produce_escalate_band(self) -> None:
+        doc  = DocumentSignal(legible=False)            # doc_score = 0.3
+        auth = AuthenticitySignal(
+            result=ToolResult(
+                verdict=Verdict.FLAG,
+                risk_score=0.9,                         # auth_score = 0.1
+                escalation=Escalation.AUTO_ACCEPT,
+                checks=[],
+            )
+        )
+        con  = ConsistencySignal(consistency_score=0.0) # con_score = 0.0
+
+        result = await _stage_score(doc, auth, con)
+
+        # weighted = 0.3×0.2 + 0.1×0.4 + 0.0×0.4 = 0.06+0.04+0.0 = 0.10
+        # score = 10 → ESCALATE (< 25)
+        assert result.band == Band.ESCALATE
+        assert result.score == 10
+
+
+# ---------------------------------------------------------------------------
+# 6. Scorer — extracted_fields passthrough
+# ---------------------------------------------------------------------------
+
+class TestExtractedFieldsPassthrough:
+    @pytest.mark.asyncio
+    async def test_extracted_fields_passed_to_result(self) -> None:
+        """POC-2 alignment: certificate data from ConsistencySignal reaches
+        ReliabilityResult.extracted_fields unchanged."""
+        doc  = DocumentSignal(legible=True)
+        auth = AuthenticitySignal(result=ToolResult(
+            verdict=Verdict.PASS, risk_score=0.1,
+            escalation=Escalation.AUTO_ACCEPT, checks=[],
+        ))
+        con  = ConsistencySignal(
+            consistency_score=0.9,
+            extracted_fields={
+                "full_name": "Jane Doe",
+                "date_of_death": "2024-05-01",
+                "cause_of_death": "cardiac arrest",
+            },
+        )
+
+        result = await _stage_score(doc, auth, con)
+
+        assert result.extracted_fields["full_name"] == "Jane Doe"
+        assert result.extracted_fields["date_of_death"] == "2024-05-01"
+        assert result.extracted_fields["cause_of_death"] == "cardiac arrest"
+
+
+# ---------------------------------------------------------------------------
+# 7. FastAPI endpoint
+# ---------------------------------------------------------------------------
+
+class TestApiEndpoint:
+    @pytest.mark.asyncio
+    async def test_score_endpoint_returns_200_and_valid_json(self) -> None:
+        import httpx
+        from poc.api import app
+
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app),
+            base_url="http://test",
+        ) as client:
+            response = await client.post(
+                "/score",
+                data={"narrative": NARRATIVE, "case_fields": "{}"},
+                files={"image": ("cert.png", io.BytesIO(FAKE_IMAGE), "image/png")},
+            )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "score" in data
+        assert "band" in data
+        assert "sub_scores" in data
+        assert "weights" in data
+        assert "justification" in data
+        assert "extracted_fields" in data
+
+    @pytest.mark.asyncio
+    async def test_score_endpoint_rejects_blank_narrative(self) -> None:
+        import httpx
+        from poc.api import app
+
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app),
+            base_url="http://test",
+        ) as client:
+            response = await client.post(
+                "/score",
+                data={"narrative": "   ", "case_fields": "{}"},
+                files={"image": ("cert.png", io.BytesIO(FAKE_IMAGE), "image/png")},
+            )
+
+        assert response.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_score_endpoint_rejects_invalid_case_fields_json(self) -> None:
+        import httpx
+        from poc.api import app
+
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app),
+            base_url="http://test",
+        ) as client:
+            response = await client.post(
+                "/score",
+                data={"narrative": NARRATIVE, "case_fields": "not-json"},
+                files={"image": ("cert.png", io.BytesIO(FAKE_IMAGE), "image/png")},
+            )
+
+        assert response.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_score_endpoint_band_is_known_value(self) -> None:
+        import httpx
+        from poc.api import app
+
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app),
+            base_url="http://test",
+        ) as client:
+            response = await client.post(
+                "/score",
+                data={"narrative": NARRATIVE, "case_fields": "{}"},
+                files={"image": ("cert.png", io.BytesIO(FAKE_IMAGE), "image/png")},
+            )
+
+        band = response.json()["band"]
+        assert band in {"high", "medium", "low", "escalate"}
+
+
+# ---------------------------------------------------------------------------
+# 8. CLI — argument parser and image resolution
+# ---------------------------------------------------------------------------
+
+class TestCli:
+    def test_cli_parser_builds_without_error(self) -> None:
+        from poc.cli import _build_parser
+        parser = _build_parser()
+        assert parser is not None
+
+    def test_cli_score_subcommand_parses_args(self, tmp_path) -> None:
+        from poc.cli import _build_parser
+
+        image_file = tmp_path / "cert.png"
+        image_file.write_bytes(FAKE_IMAGE)
+
+        parser = _build_parser()
+        args = parser.parse_args([
+            "score",
+            "--image", str(image_file),
+            "--narrative", NARRATIVE,
+            "--fields", '{"case_id": "X1"}',
+        ])
+
+        assert args.command == "score"
+        assert args.narrative == NARRATIVE
+        assert json.loads(args.fields) == {"case_id": "X1"}
+
+    @pytest.mark.asyncio
+    async def test_resolve_image_reads_local_file(self, tmp_path) -> None:
+        from poc.cli import _resolve_image
+
+        image_file = tmp_path / "cert.png"
+        image_file.write_bytes(FAKE_IMAGE)
+
+        result = await _resolve_image(str(image_file))
+        assert result == FAKE_IMAGE
+
+    @pytest.mark.asyncio
+    async def test_resolve_image_local_missing_file_exits(self, tmp_path) -> None:
+        from poc.cli import _resolve_image
+
+        with pytest.raises(SystemExit):
+            await _resolve_image(str(tmp_path / "nonexistent.png"))
+
+    @pytest.mark.asyncio
+    async def test_resolve_image_downloads_from_gcs(self, monkeypatch) -> None:
+        """GCS URI is parsed correctly and download_as_bytes is called."""
+        from unittest.mock import MagicMock
+        from poc.cli import _resolve_image
+
+        mock_blob = MagicMock()
+        mock_blob.download_as_bytes.return_value = FAKE_IMAGE
+
+        mock_bucket = MagicMock()
+        mock_bucket.blob.return_value = mock_blob
+
+        mock_client = MagicMock()
+        mock_client.bucket.return_value = mock_bucket
+
+        mock_storage = MagicMock()
+        mock_storage.Client.return_value = mock_client
+
+        monkeypatch.setitem(__import__("sys").modules, "google.cloud.storage", mock_storage)
+        monkeypatch.setitem(__import__("sys").modules, "google.cloud", MagicMock(storage=mock_storage))
+
+        result = await _resolve_image("gs://my-bucket/certs/cert.jpg")
+
+        mock_client.bucket.assert_called_once_with("my-bucket")
+        mock_bucket.blob.assert_called_once_with("certs/cert.jpg")
+        mock_blob.download_as_bytes.assert_called_once()
+        assert result == FAKE_IMAGE
+
+    @pytest.mark.asyncio
+    async def test_resolve_image_invalid_gcs_uri_exits(self, monkeypatch) -> None:
+        """A GCS URI with no blob path exits with an error."""
+        from unittest.mock import MagicMock
+        from poc.cli import _resolve_image
+
+        mock_storage = MagicMock()
+        monkeypatch.setitem(__import__("sys").modules, "google.cloud.storage", mock_storage)
+        monkeypatch.setitem(__import__("sys").modules, "google.cloud", MagicMock(storage=mock_storage))
+
+        with pytest.raises(SystemExit):
+            await _resolve_image("gs://bucket-only-no-blob")


### PR DESCRIPTION
## Overview

This PR (#30) builds the skeleton that every other POC ticket plugs into. It defines the data contracts, wires them through a linear pipeline with stubbed stages, and provides two ways to feed input in: a FastAPI endpoint and a CLI that supports both local files and GCS URIs.

All models are frozen. POC-2 can build against these contracts today.

---

## Data Models — `poc/models.py`

Five typed Pydantic models define the full input-to-output contract:

- **`Submission`**: what comes in. `image` (bytes), `narrative` (first-class, required, non-blank), `case_fields` (free-form dict for case metadata)
- **`DocumentSignal`**: output of the document analysis stage. Covers legibility, document type, page count, language hint
- **`AuthenticitySignal`**: output of the authenticity stage. Wraps `ToolResult` from the existing fake image detector directly; zero translation needed
- **`ConsistencySignal`**: output of the narrative consistency stage. Maps straight from `analyze_death_certificate_consistency()`; carries `extracted_fields` through to the final result
- **`ReliabilityResult`**: what goes out. Score (1–100), band, sub-scores, weights, flags, justification, and extracted certificate fields surfaced to the customer

**`Band` enum:** `high` (75–100) · `medium` (50–74) · `low` (25–49) · `escalate` (0–24 or forced by hard flag)

---

## Pipeline — `poc/pipeline.py`

`run_pipeline(submission)` runs six stages in order:

```
intake → document analysis → authenticity → consistency → scorer → result
```

All stage functions are `async def` so POC-2's real implementations (the fake image detector is async) drop straight in without touching the function signature.

**Stub defaults produce:** `score=88`, `band=high`

**Scorer logic:**
- Hard escalation from the authenticity stage (`HUMAN_REVIEW` or `AUTO_REJECT`) forces `band=escalate` and adds a `HARD_ESCALATION` flag regardless of the numeric score, wired directly to the fake image detector's existing escalation semantics
- Score below 25 also triggers `escalate` without a hard flag
- `extracted_fields` passes through from `ConsistencySignal` to `ReliabilityResult` unchanged

---

## Input Layer

**FastAPI — `poc/api.py`**
```
POST /score
  image       — certificate image (multipart upload)
  narrative   — claimant's free-text narrative
  case_fields — JSON string of case metadata (optional)
```

**CLI — `poc/cli.py`**

Supports both local files and GCS URIs:
```
python -m poc.cli score \
  --image gs://your-bucket/cert.jpg \
  --narrative "My father passed away on March 3rd." \
  --fields '{"case_id": "ABC-123"}'
```

The CLI detects the `gs://` prefix, downloads the image bytes from the bucket, and hands them to the pipeline as usual. `Submission` always receives bytes so nothing downstream changes. Clear error messages for missing credentials, malformed URIs, and failed downloads.

---

## POC-2 Integration Points

| POC-2 component | How it plugs in |
|---|---|
| `FakeImageDetectorPipeline.run()` | `AuthenticitySignal(result=tool_result)`  - no translation |
| `analyze_death_certificate_consistency()` | Maps to `ConsistencySignal` - only rename is `mismatches` → `contradictions` |
| `extracted_fields` (certificate data) | Passes from `ConsistencySignal` → `ReliabilityResult.extracted_fields` unchanged |

**Note for POC-2:** `analyze_death_certificate_consistency()` currently raises `ValueError` when `GEMINI_API_KEY` is missing. The stub adapter returning sample JSON when credentials are unavailable needs to be added on the POC-2 side before wiring in.

---

## Test Coverage

| File | Tests | What's covered |
|---|---|---|
| `tests/unit/poc/test_pipeline.py` | 34 | Model construction, narrative validation, band enum, pipeline end-to-end, escalation paths, `extracted_fields` passthrough, FastAPI endpoint, CLI with GCS URI |

---

## What's Next

- [ ] POC-2: Replace `_stage_authenticity` stub with real `FakeImageDetectorPipeline.run()` call
- [ ] POC-2: Replace `_stage_consistency` stub with real `analyze_death_certificate_consistency()` call
- [ ] POC-2: Replace `_stage_document` stub with Gemini document analysis
- [ ] POC-2: Add stub LLM adapter returning sample JSON when credentials are unavailable
