### PR TITLE
feat: switch Gemini model provider from API key to Vertex AI

### DIFF
--- a/src/orchestrator/agent.py
+++ b/src/orchestrator/agent.py
@@ -150,12 +150,18 @@ class Agent:
 
     @classmethod
     def _build_gemini_model(cls, provider: dict[str, Any], model_name: str) -> tuple[GoogleModel, dict[str, Any]]:
-        api_key = os.getenv("GEMINI_API_KEY")
-        if not api_key:
-            raise ValueError("GEMINI_API_KEY is required to run Gemini agents.")
+        project = provider.get("project") or os.getenv("GOOGLE_CLOUD_PROJECT")
+        location = provider.get("location") or os.getenv("VERTEX_LOCATION", "us-central1")
 
         model_settings = cls._model_settings_from_provider(provider, model_name)
-        model = GoogleModel(model_name, provider=GoogleProvider(api_key=api_key))
+        model = GoogleModel(
+            model_name,
+            provider=GoogleProvider(
+                vertexai=True,
+                project=project,
+                location=location,
+            ),
+        )
         return model, model_settings
 
     @classmethod


### PR DESCRIPTION
This pull request switches the Gemini model provider from API key-based authentication to Vertex AI using Application Default Credentials. This allows the agent system to authenticate through GCP's ADC rather than requiring a GEMINI_API_KEY environment variable.

The original implementation was built before GCP was set up, so it relied on a direct API key. Now that the b2-platform project is configured with Vertex AI enabled, the provider can use ADC for authentication, which is more secure and aligns with the rest of the codebase's GCP integration.

Vertex AI Provider Integration:

- Updated _build_gemini_model in src/orchestrator/agent.py to use GoogleProvider with vertexai=True, resolving project and location from provider config or environment variables (GOOGLE_CLOUD_PROJECT, VERTEX_LOCATION). Removed the GEMINI_API_KEY requirement and its associated error.
- Tested live against Vertex AI on the b2-platform project — agent initialized and responded successfully.
