### PR TITLE
feat: persist chat session history in Firestore

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ pydantic-settings>=2.3.0
 pydantic>=2.8.0
 pydantic-ai>=0.0.14
 google-genai>=1.0.0
+google-cloud-firestore>=2.0.0
 numpy>=1.26.0
 pyyaml>=6.0
 python-dotenv>=1.0

--- a/src/chat.py
+++ b/src/chat.py
@@ -7,6 +7,7 @@ from pydantic_ai.messages import BinaryImage, ImageUrl, TextContent, UserContent
 
 from .router import AgentRouter
 from .session import Session
+from .session_store import FirestoreSessionStore
 
 DEFAULT_IMAGE_MEDIA_TYPE = "image/jpeg"
 IMAGE_PROMPT_TEXT = "The user sent this image on WhatsApp. Analyze it and provide a helpful response."
@@ -19,6 +20,8 @@ def chat(
     image_bytes: bytes | None = None,
     image_url: str | None = None,
     image_media_type: str = DEFAULT_IMAGE_MEDIA_TYPE,
+    session_id: str | None = None,
+    channel: str = "whatsapp",
 ) -> str:
     """Route one WhatsApp text or image message through the agent loop and return the response."""
 
@@ -33,9 +36,19 @@ def chat(
 
     router = AgentRouter()
     agent, _metadata = router.route_with_metadata(route_query)
-    session = Session(agent)
+    store = FirestoreSessionStore() if session_id is not None else None
+    history = store.load_history(session_id) if store is not None else None
+    session = Session(agent, history=history)
 
-    return "".join(session.send_stream(prompt))
+    response = "".join(session.send_stream(prompt))
+    if store is not None:
+        store.save_history(
+            session_id,
+            session.history,
+            agent_name=getattr(agent, "name", None),
+            channel=channel,
+        )
+    return response
 
 
 def _build_prompt(

--- a/src/session.py
+++ b/src/session.py
@@ -10,9 +10,13 @@ logger = logging.getLogger(__name__)
 
 
 class Session:
-    def __init__(self, agent: Agent):
+    def __init__(self, agent: Agent, history: Sequence[ModelMessage] | None = None):
         self.agent = agent
-        self._history: list[ModelMessage] = []
+        self._history: list[ModelMessage] = list(history or [])
+
+    @property
+    def history(self) -> list[ModelMessage]:
+        return list(self._history)
 
     def send_stream(self, user_message: str | Sequence[UserContent]):
         start = perf_counter()

--- a/src/session_store.py
+++ b/src/session_store.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import os
+from collections.abc import Callable, Sequence
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+from pydantic_ai.messages import ModelMessage, ModelMessagesTypeAdapter
+
+DEFAULT_SESSION_TTL = timedelta(hours=72)
+
+
+class FirestoreSessionStore:
+    def __init__(
+        self,
+        *,
+        client: Any | None = None,
+        project: str | None = None,
+        collection: str = "sessions",
+        server_timestamp: Any | None = None,
+        ttl: timedelta = DEFAULT_SESSION_TTL,
+        now: Callable[[], datetime] | None = None,
+    ):
+        firestore = None if client is not None else _firestore_module()
+        self._client = client or firestore.Client(project=project or os.getenv("GOOGLE_CLOUD_PROJECT"))
+        self._collection = collection
+        self._server_timestamp = (
+            server_timestamp
+            if server_timestamp is not None
+            else (firestore or _firestore_module()).SERVER_TIMESTAMP
+        )
+        self._ttl = ttl
+        self._now = now or _utc_now
+
+    def load_history(self, session_id: str) -> list[ModelMessage]:
+        document = self._document(session_id)
+        snapshot = document.get()
+        if not snapshot.exists:
+            return []
+
+        data = snapshot.to_dict() or {}
+        expires_at = data.get("expires_at")
+        if isinstance(expires_at, datetime) and expires_at <= self._now():
+            document.delete()
+            return []
+
+        history = data.get("history") or []
+        return list(ModelMessagesTypeAdapter.validate_python(history))
+
+    def save_history(
+        self,
+        session_id: str,
+        history: Sequence[ModelMessage],
+        *,
+        agent_name: str | None = None,
+        channel: str | None = None,
+    ) -> None:
+        document = self._document(session_id)
+        snapshot = document.get()
+        data: dict[str, Any] = {
+            "session_id": session_id,
+            "history": ModelMessagesTypeAdapter.dump_python(history, mode="json"),
+            "updated_at": self._server_timestamp,
+            "expires_at": self._now() + self._ttl,
+        }
+
+        if not snapshot.exists:
+            data["created_at"] = self._server_timestamp
+        if agent_name is not None:
+            data["agent_name"] = agent_name
+        if channel is not None:
+            data["channel"] = channel
+
+        document.set(data, merge=True)
+
+    def _document(self, session_id: str) -> Any:
+        return self._client.collection(self._collection).document(session_id)
+
+
+def _firestore_module() -> Any:
+    from google.cloud import firestore
+
+    return firestore
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)

--- a/tests/unit/test_chat.py
+++ b/tests/unit/test_chat.py
@@ -58,14 +58,18 @@ def test_build_prompt_rejects_multiple_inputs() -> None:
 
 
 def test_chat_routes_and_returns_streamed_text(monkeypatch) -> None:
+    created_sessions = []
+
     class FakeRouter:
         def route_with_metadata(self, query: str):
             assert query == "hello"
             return object(), {"score": 1.0}
 
     class FakeSession:
-        def __init__(self, agent: object):
+        def __init__(self, agent: object, history=None):
             self.agent = agent
+            self.history = list(history or [])
+            created_sessions.append(self)
 
         def send_stream(self, prompt: str):
             assert prompt == "hello"
@@ -75,5 +79,58 @@ def test_chat_routes_and_returns_streamed_text(monkeypatch) -> None:
     monkeypatch.setattr(chat_module, "load_dotenv", lambda: None)
     monkeypatch.setattr(chat_module, "AgentRouter", FakeRouter)
     monkeypatch.setattr(chat_module, "Session", FakeSession)
+    monkeypatch.setattr(
+        chat_module,
+        "FirestoreSessionStore",
+        lambda: (_ for _ in ()).throw(AssertionError("store should not be used")),
+    )
 
     assert chat(text="hello") == "hi there"
+    assert created_sessions[0].history == []
+
+
+def test_chat_loads_and_saves_stateful_history(monkeypatch) -> None:
+    loaded_history = [object()]
+    saved = {}
+
+    class FakeAgent:
+        name = "support"
+
+    class FakeRouter:
+        def route_with_metadata(self, query: str):
+            assert query == "hello"
+            return FakeAgent(), {"score": 1.0}
+
+    class FakeStore:
+        def load_history(self, session_id: str):
+            assert session_id == "session-1"
+            return loaded_history
+
+        def save_history(self, session_id: str, history, *, agent_name=None, channel=None) -> None:
+            saved["session_id"] = session_id
+            saved["history"] = history
+            saved["agent_name"] = agent_name
+            saved["channel"] = channel
+
+    class FakeSession:
+        def __init__(self, agent: object, history=None):
+            assert isinstance(agent, FakeAgent)
+            assert history == loaded_history
+            self.history = ["updated"]
+
+        def send_stream(self, prompt: str):
+            assert prompt == "hello"
+            yield "hi"
+
+    monkeypatch.setattr(chat_module, "load_dotenv", lambda: None)
+    monkeypatch.setattr(chat_module, "AgentRouter", FakeRouter)
+    monkeypatch.setattr(chat_module, "Session", FakeSession)
+    monkeypatch.setattr(chat_module, "FirestoreSessionStore", FakeStore)
+
+    assert chat(text="hello", session_id="session-1", channel="sms") == "hi"
+    assert saved == {
+        "session_id": "session-1",
+        "history": ["updated"],
+        "agent_name": "support",
+        "channel": "sms",
+    }

--- a/tests/unit/test_session_store.py
+++ b/tests/unit/test_session_store.py
@@ -1,0 +1,135 @@
+from datetime import datetime, timedelta, timezone
+
+from pydantic_ai.messages import ModelMessagesTypeAdapter, ModelRequest, ModelResponse, TextPart, UserPromptPart
+
+from src.session_store import FirestoreSessionStore
+
+
+class FakeSnapshot:
+    def __init__(self, exists: bool, data=None):
+        self.exists = exists
+        self._data = data
+
+    def to_dict(self):
+        return self._data
+
+
+class FakeDocument:
+    def __init__(self, snapshot: FakeSnapshot):
+        self.snapshot = snapshot
+        self.writes = []
+        self.deletes = 0
+
+    def get(self):
+        return self.snapshot
+
+    def set(self, data, *, merge: bool):
+        self.writes.append((data, merge))
+        self.snapshot = FakeSnapshot(True, data)
+
+    def delete(self):
+        self.deletes += 1
+        self.snapshot = FakeSnapshot(False)
+
+
+class FakeCollection:
+    def __init__(self, document: FakeDocument):
+        self.document_ref = document
+
+    def document(self, session_id: str):
+        assert session_id == "session-1"
+        return self.document_ref
+
+
+class FakeClient:
+    def __init__(self, document: FakeDocument):
+        self.document_ref = document
+        self.collection_name = None
+
+    def collection(self, name: str):
+        self.collection_name = name
+        return FakeCollection(self.document_ref)
+
+
+def test_load_history_deserializes_stored_messages() -> None:
+    now = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    history = [
+        ModelRequest(parts=[UserPromptPart(content="hello")]),
+        ModelResponse(parts=[TextPart(content="hi")]),
+    ]
+    store = FirestoreSessionStore(
+        client=FakeClient(
+            FakeDocument(
+                FakeSnapshot(
+                    True,
+                    {
+                        "history": ModelMessagesTypeAdapter.dump_python(history, mode="json"),
+                        "expires_at": now + timedelta(hours=1),
+                    },
+                )
+            )
+        ),
+        server_timestamp="SERVER_TIME",
+        now=lambda: now,
+    )
+
+    assert store.load_history("session-1") == history
+
+
+def test_load_history_returns_empty_list_and_deletes_expired_document() -> None:
+    now = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    document = FakeDocument(
+        FakeSnapshot(
+            True,
+            {
+                "history": ModelMessagesTypeAdapter.dump_python(
+                    [ModelRequest(parts=[UserPromptPart(content="hello")])],
+                    mode="json",
+                ),
+                "expires_at": now,
+            },
+        )
+    )
+    store = FirestoreSessionStore(
+        client=FakeClient(document),
+        server_timestamp="SERVER_TIME",
+        now=lambda: now,
+    )
+
+    assert store.load_history("session-1") == []
+    assert document.deletes == 1
+
+
+def test_load_history_returns_empty_list_for_missing_document() -> None:
+    store = FirestoreSessionStore(
+        client=FakeClient(FakeDocument(FakeSnapshot(False))),
+        server_timestamp="SERVER_TIME",
+    )
+
+    assert store.load_history("session-1") == []
+
+
+def test_save_history_serializes_messages_and_sets_metadata_on_create() -> None:
+    now = datetime(2026, 1, 1, 12, 0, tzinfo=timezone.utc)
+    document = FakeDocument(FakeSnapshot(False))
+    client = FakeClient(document)
+    store = FirestoreSessionStore(client=client, server_timestamp="SERVER_TIME", now=lambda: now)
+    history = [
+        ModelRequest(parts=[UserPromptPart(content="hello")]),
+        ModelResponse(parts=[TextPart(content="hi")]),
+    ]
+
+    store.save_history("session-1", history, agent_name="support", channel="whatsapp")
+
+    assert client.collection_name == "sessions"
+    assert len(document.writes) == 1
+    data, merge = document.writes[0]
+    assert merge is True
+    assert data["session_id"] == "session-1"
+    assert data["updated_at"] == "SERVER_TIME"
+    assert data["created_at"] == "SERVER_TIME"
+    assert data["expires_at"] == now + timedelta(hours=72)
+    assert data["agent_name"] == "support"
+    assert data["channel"] == "whatsapp"
+    assert data["history"][0]["kind"] == "request"
+    assert data["history"][1]["kind"] == "response"


### PR DESCRIPTION
## Summary

- Add a Firestore-backed session store for chat history keyed by `session_id`.
- Restore saved Pydantic AI message history when `chat()` is called with a `session_id`.
- Save updated history after each stateful chat call while preserving stateless behavior when no `session_id` is provided.
- Add a 72-hour `expires_at` field for Firestore TTL and app-side expiry/deletion on load.

## Notes

- Webhook work is intentionally out of scope; the future WhatsApp adapter only needs to pass a stable session-safe ID into `chat()`.
- Real Firestore smoke testing is deferred until GCP auth/Firestore setup is ready.

## Validation

- `uv run --with pytest python -m pytest tests/unit/test_session_store.py tests/unit/test_chat.py` passed: 10 tests.
- `git diff --check` passed.
- Compile check passed for `src` and the focused tests.
