### PR TITLE
WhatsApp Channel Adapter: POST /message endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,3 @@ tools/fake_image_detector/local_samples/
 tools/fake_image_detector/models/
 tests/fixtures/dataset/
 
-# Docker
-Dockerfile
-Dockerfile*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+COPY requirements-api.txt .
+RUN pip install --no-cache-dir -r requirements-api.txt
+
+COPY src/ ./src/
+COPY agents/ ./agents/
+COPY skills/ ./skills/
+COPY tools/ ./tools/
+
+ENV PORT=8080
+EXPOSE 8080
+
+CMD ["uvicorn", "src.api:app", "--host", "0.0.0.0", "--port", "8080"]

--- a/agents/whatsapp_agent.yaml
+++ b/agents/whatsapp_agent.yaml
@@ -1,0 +1,29 @@
+name: whatsapp_agent
+
+description: >
+  A general-purpose conversational assistant for the B2 Platform, accessible via WhatsApp.
+  Handles diverse queries including questions about Givelight, orphan aid programmes, document
+  submission guidance, general information requests, greetings, and any topic not covered by
+  a more specialised agent. Acts as the default fallback for all WhatsApp conversations.
+
+system_prompt: |
+  You are B2, a compassionate and knowledgeable assistant for the B2 Platform built by B2 Foundation.
+  You help users — primarily families and caregivers seeking orphan aid — navigate the Givelight
+  programme and related services.
+
+  Your responsibilities:
+  - Answer questions about Givelight, orphan aid eligibility, and the application process
+  - Guide users on how to submit documents (death certificates, identification, etc.)
+  - Respond warmly and clearly to greetings and general queries
+  - Direct users to the right resource or next step when you cannot directly help
+
+  Tone: compassionate, clear, concise. Messages may be in English, Arabic, or French — respond
+  in the same language the user wrote in. Keep replies brief and suitable for WhatsApp (no markdown
+  headers or bullet lists unless explicitly helpful). Never ask for sensitive personal data unless
+  the user has already volunteered it.
+
+provider:
+  type: gemini
+  model: gemini-2.0-flash
+  settings:
+    thinking_budget: 0

--- a/requirements-api.txt
+++ b/requirements-api.txt
@@ -1,0 +1,14 @@
+# Slim dependency set for the b2-whatsapp-adapter Cloud Run service.
+# Excludes heavy ML deps (spacy, onnxruntime, presidio, pillow, passporteye)
+# that are only needed for GL-1 PII scrubbing and GL-9 image detection.
+# No GEMINI_API_KEY required — embedder and agents both use Vertex AI via ADC.
+fastapi>=0.115.0
+uvicorn[standard]>=0.30.0
+pydantic>=2.8.0
+pydantic-settings>=2.3.0
+pydantic-ai>=0.0.14
+google-genai>=1.0.0
+numpy>=1.26.0
+pyyaml>=6.0
+python-dotenv>=1.0
+httpx>=0.27.0

--- a/requirements-api.txt
+++ b/requirements-api.txt
@@ -6,7 +6,7 @@ fastapi>=0.115.0
 uvicorn[standard]>=0.30.0
 pydantic>=2.8.0
 pydantic-settings>=2.3.0
-pydantic-ai>=0.0.14
+pydantic-ai==1.98.0
 google-genai>=1.0.0
 numpy>=1.26.0
 pyyaml>=6.0

--- a/requirements-api.txt
+++ b/requirements-api.txt
@@ -8,6 +8,7 @@ pydantic>=2.8.0
 pydantic-settings>=2.3.0
 pydantic-ai==1.98.0
 google-genai>=1.0.0
+google-cloud-firestore>=2.0.0
 numpy>=1.26.0
 pyyaml>=6.0
 python-dotenv>=1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ fastapi>=0.115.0
 uvicorn[standard]>=0.30.0
 pydantic-settings>=2.3.0
 pydantic>=2.8.0
-pydantic-ai>=0.0.14
+pydantic-ai==1.98.0
 google-genai>=1.0.0
 numpy>=1.26.0
 pyyaml>=6.0

--- a/src/api.py
+++ b/src/api.py
@@ -11,6 +11,7 @@ import os
 from typing import Any
 
 from fastapi import FastAPI, Header, HTTPException, Request
+from starlette.concurrency import run_in_threadpool
 
 from .chat import chat
 
@@ -63,7 +64,7 @@ async def message_endpoint(
         return {"response": None}
 
     logger.info("api.message routing wa_id=%s chars=%d", wa_id, len(text))
-    response = chat(text=text)
+    response = await run_in_threadpool(chat, text=text)
     logger.info("api.message done wa_id=%s response_chars=%d", wa_id, len(response))
     return {"response": response}
 

--- a/src/api.py
+++ b/src/api.py
@@ -1,0 +1,73 @@
+"""FastAPI entry point for the b2 WhatsApp Channel Adapter.
+
+Exposes POST /message — called by the central benevolent-bandwidth webhook
+for every inbound WhatsApp message routed to b2-platform.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any
+
+from fastapi import FastAPI, Header, HTTPException, Request
+
+from .chat import chat
+
+logger = logging.getLogger(__name__)
+
+app = FastAPI(title="b2 WhatsApp Adapter")
+
+_WEBHOOK_SECRET = os.getenv("WEBHOOK_SECRET", "")
+
+
+def _extract_message(payload: dict[str, Any]) -> tuple[str | None, str | None]:
+    """Return (wa_id, text) for a text message, or (None, None) for anything else."""
+    try:
+        entry = (payload.get("entry") or [])[0]
+        value = (entry.get("changes") or [])[0].get("value", {})
+        contacts = value.get("contacts") or []
+        messages = value.get("messages") or []
+
+        if not messages:
+            return None, None
+
+        msg = messages[0]
+        if msg.get("type") != "text":
+            return None, None
+
+        wa_id = (contacts[0].get("wa_id") if contacts else None) or msg.get("from")
+        text = (msg.get("text") or {}).get("body", "").strip()
+        if not text:
+            return None, None
+
+        return wa_id, text
+    except (IndexError, AttributeError, TypeError, KeyError):
+        return None, None
+
+
+@app.post("/message")
+async def message_endpoint(
+    request: Request,
+    x_webhook_secret: str | None = Header(default=None),
+) -> dict[str, str | None]:
+    if _WEBHOOK_SECRET and x_webhook_secret != _WEBHOOK_SECRET:
+        raise HTTPException(status_code=401, detail="Unauthorized")
+
+    payload = await request.json()
+    logger.info("api.message received object=%s", payload.get("object"))
+
+    wa_id, text = _extract_message(payload)
+    if text is None:
+        logger.info("api.message skipped — no text payload")
+        return {"response": None}
+
+    logger.info("api.message routing wa_id=%s chars=%d", wa_id, len(text))
+    response = chat(text=text)
+    logger.info("api.message done wa_id=%s response_chars=%d", wa_id, len(response))
+    return {"response": response}
+
+
+@app.get("/health")
+def health() -> dict[str, str]:
+    return {"status": "ok"}

--- a/src/api.py
+++ b/src/api.py
@@ -64,7 +64,7 @@ async def message_endpoint(
         return {"response": None}
 
     logger.info("api.message routing wa_id=%s chars=%d", wa_id, len(text))
-    response = await run_in_threadpool(chat, text=text)
+    response = await run_in_threadpool(chat, text=text, session_id=wa_id)
     logger.info("api.message done wa_id=%s response_chars=%d", wa_id, len(response))
     return {"response": response}
 

--- a/src/chat.py
+++ b/src/chat.py
@@ -8,9 +8,20 @@ from pydantic_ai.messages import BinaryImage, ImageUrl, TextContent, UserContent
 from .router import AgentRouter
 from .session import Session
 
+load_dotenv()
+
 DEFAULT_IMAGE_MEDIA_TYPE = "image/jpeg"
 IMAGE_PROMPT_TEXT = "The user sent this image on WhatsApp. Analyze it and provide a helpful response."
 IMAGE_ROUTING_TEXT = "A WhatsApp user sent an image and needs help interpreting or responding to it."
+
+_router: AgentRouter | None = None
+
+
+def _get_router() -> AgentRouter:
+    global _router
+    if _router is None:
+        _router = AgentRouter()
+    return _router
 
 
 def chat(
@@ -22,7 +33,6 @@ def chat(
 ) -> str:
     """Route one WhatsApp text or image message through the agent loop and return the response."""
 
-    load_dotenv()
     prompt = _build_prompt(
         text=text,
         image_bytes=image_bytes,
@@ -31,7 +41,7 @@ def chat(
     )
     route_query = text.strip() if text is not None else IMAGE_ROUTING_TEXT
 
-    router = AgentRouter()
+    router = _get_router()
     agent, _metadata = router.route_with_metadata(route_query)
     session = Session(agent)
 

--- a/src/embeddings.py
+++ b/src/embeddings.py
@@ -23,11 +23,11 @@ class GoogleEmbedder:
     ) -> None:
         self.model = model
         self.output_dimensionality = output_dimensionality
-        self._client = genai.Client(
-            vertexai=True,
-            project=project or os.getenv("GOOGLE_CLOUD_PROJECT"),
-            location=location or os.getenv("VERTEX_LOCATION", "us-east1"),
-        )
+        vertex_project = project or os.getenv("GOOGLE_CLOUD_PROJECT")
+        if not vertex_project:
+            raise ValueError("GOOGLE_CLOUD_PROJECT is required for Vertex AI embeddings (or pass project=...)")
+        vertex_location = location or os.getenv("VERTEX_LOCATION", "us-central1")
+        self._client = genai.Client(vertexai=True, project=vertex_project, location=vertex_location)
 
     @staticmethod
     def _l2_normalize(vectors: np.ndarray) -> np.ndarray:

--- a/src/embeddings.py
+++ b/src/embeddings.py
@@ -5,23 +5,29 @@ import numpy as np
 from google import genai
 from google.genai import types
 
+# Vertex AI text-embedding-004: 768-dim, same as prior model, no API key required.
+# Uses ADC (Application Default Credentials) — Cloud Run service account supplies these.
+_DEFAULT_MODEL = "text-embedding-004"
+_DEFAULT_DIM = 768
+
 
 class GoogleEmbedder:
-    """Gemini embedding wrapper for document and query embeddings."""
+    """Vertex AI embedding wrapper for document and query embeddings."""
 
     def __init__(
         self,
-        model: str = "gemini-embedding-001",
-        output_dimensionality: int = 768,
-        api_key: str | None = None,
+        model: str = _DEFAULT_MODEL,
+        output_dimensionality: int = _DEFAULT_DIM,
+        project: str | None = None,
+        location: str | None = None,
     ) -> None:
         self.model = model
         self.output_dimensionality = output_dimensionality
-        self.api_key = api_key or os.getenv("GEMINI_API_KEY")
-        if not self.api_key:
-            raise ValueError("GEMINI_API_KEY is required for Gemini embeddings.")
-
-        self._client = genai.Client(api_key=self.api_key)
+        self._client = genai.Client(
+            vertexai=True,
+            project=project or os.getenv("GOOGLE_CLOUD_PROJECT"),
+            location=location or os.getenv("VERTEX_LOCATION", "us-east1"),
+        )
 
     @staticmethod
     def _l2_normalize(vectors: np.ndarray) -> np.ndarray:

--- a/src/orchestrator/agent.py
+++ b/src/orchestrator/agent.py
@@ -142,7 +142,7 @@ class Agent:
     @classmethod
     def _build_gemini_model(cls, provider: dict[str, Any], model_name: str) -> tuple[GoogleModel, dict[str, Any]]:
         project = provider.get("project") or os.getenv("GOOGLE_CLOUD_PROJECT")
-        location = provider.get("location") or os.getenv("VERTEX_LOCATION", "us-central1")
+        location = provider.get("location") or os.getenv("VERTEX_LOCATION", "us-east1")
 
         model_settings = cls._model_settings_from_provider(provider, model_name)
         model = GoogleModel(

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -197,8 +197,9 @@ def test_message_text_calls_chat(monkeypatch):
 
     captured = {}
 
-    def fake_chat(*, text, **kwargs):
+    def fake_chat(*, text, session_id, **kwargs):
         captured["text"] = text
+        captured["session_id"] = session_id
         return "Givelight is an orphan aid programme."
 
     monkeypatch.setattr(api_module, "chat", fake_chat)
@@ -208,6 +209,7 @@ def test_message_text_calls_chat(monkeypatch):
     assert r.status_code == 200
     assert r.json() == {"response": "Givelight is an orphan aid programme."}
     assert captured["text"] == "Hello B2, what is Givelight?"
+    assert captured["session_id"] == "16508106640"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -1,0 +1,251 @@
+"""Unit tests for src/api.py — WhatsApp Channel Adapter endpoint."""
+
+import importlib
+import os
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+SAMPLE_TEXT_PAYLOAD = {
+    "object": "whatsapp_business_account",
+    "entry": [
+        {
+            "id": "1745012400192435",
+            "changes": [
+                {
+                    "value": {
+                        "messaging_product": "whatsapp",
+                        "metadata": {
+                            "display_phone_number": "16179164660",
+                            "phone_number_id": "1104821716055506",
+                        },
+                        "contacts": [
+                            {"profile": {"name": "Test User"}, "wa_id": "16508106640"}
+                        ],
+                        "messages": [
+                            {
+                                "from": "16508106640",
+                                "id": "wamid.test",
+                                "timestamp": "1780358445",
+                                "text": {"body": "Hello B2, what is Givelight?"},
+                                "type": "text",
+                            }
+                        ],
+                    },
+                    "field": "messages",
+                }
+            ],
+        }
+    ],
+}
+
+STATUS_UPDATE_PAYLOAD = {
+    "object": "whatsapp_business_account",
+    "entry": [
+        {
+            "id": "1745012400192435",
+            "changes": [
+                {
+                    "value": {
+                        "messaging_product": "whatsapp",
+                        "statuses": [
+                            {
+                                "id": "wamid.test",
+                                "status": "delivered",
+                                "timestamp": "1780358446",
+                                "recipient_id": "16508106640",
+                            }
+                        ],
+                    },
+                    "field": "messages",
+                }
+            ],
+        }
+    ],
+}
+
+IMAGE_PAYLOAD = {
+    "object": "whatsapp_business_account",
+    "entry": [
+        {
+            "id": "1745012400192435",
+            "changes": [
+                {
+                    "value": {
+                        "messaging_product": "whatsapp",
+                        "contacts": [
+                            {"profile": {"name": "Test User"}, "wa_id": "16508106640"}
+                        ],
+                        "messages": [
+                            {
+                                "from": "16508106640",
+                                "id": "wamid.test2",
+                                "timestamp": "1780358447",
+                                "type": "image",
+                                "image": {"id": "media-123", "mime_type": "image/jpeg"},
+                            }
+                        ],
+                    },
+                    "field": "messages",
+                }
+            ],
+        }
+    ],
+}
+
+
+def _make_client(secret: str = "", monkeypatch=None):
+    """Import api module fresh with WEBHOOK_SECRET env var set."""
+    if monkeypatch is not None:
+        monkeypatch.setenv("WEBHOOK_SECRET", secret)
+
+    # Re-import to pick up env var at module level
+    import src.api as api_module
+    importlib.reload(api_module)
+    return TestClient(api_module.app), api_module
+
+
+# ---------------------------------------------------------------------------
+# _extract_message unit tests
+# ---------------------------------------------------------------------------
+
+def test_extract_message_text():
+    from src.api import _extract_message
+    wa_id, text = _extract_message(SAMPLE_TEXT_PAYLOAD)
+    assert wa_id == "16508106640"
+    assert text == "Hello B2, what is Givelight?"
+
+
+def test_extract_message_status_update_returns_none():
+    from src.api import _extract_message
+    wa_id, text = _extract_message(STATUS_UPDATE_PAYLOAD)
+    assert wa_id is None
+    assert text is None
+
+
+def test_extract_message_image_returns_none():
+    from src.api import _extract_message
+    wa_id, text = _extract_message(IMAGE_PAYLOAD)
+    assert wa_id is None
+    assert text is None
+
+
+def test_extract_message_empty_payload():
+    from src.api import _extract_message
+    wa_id, text = _extract_message({})
+    assert wa_id is None
+    assert text is None
+
+
+def test_extract_message_blank_text():
+    from src.api import _extract_message
+    payload = {
+        "entry": [{"changes": [{"value": {"messages": [{"type": "text", "text": {"body": "  "}, "from": "123"}]}}]}]
+    }
+    wa_id, text = _extract_message(payload)
+    assert wa_id is None
+    assert text is None
+
+
+# ---------------------------------------------------------------------------
+# /health endpoint
+# ---------------------------------------------------------------------------
+
+def test_health():
+    from src.api import app
+    client = TestClient(app)
+    r = client.get("/health")
+    assert r.status_code == 200
+    assert r.json() == {"status": "ok"}
+
+
+# ---------------------------------------------------------------------------
+# /message — no secret configured (open mode)
+# ---------------------------------------------------------------------------
+
+def test_message_status_update_returns_null(monkeypatch):
+    import src.api as api_module
+    monkeypatch.setenv("WEBHOOK_SECRET", "")
+    monkeypatch.setattr(api_module, "_WEBHOOK_SECRET", "")
+
+    def fake_chat(**kwargs):
+        return "should not be called"
+
+    monkeypatch.setattr(api_module, "chat", fake_chat)
+
+    client = TestClient(api_module.app)
+    r = client.post("/message", json=STATUS_UPDATE_PAYLOAD)
+    assert r.status_code == 200
+    assert r.json() == {"response": None}
+
+
+def test_message_image_returns_null(monkeypatch):
+    import src.api as api_module
+    monkeypatch.setattr(api_module, "_WEBHOOK_SECRET", "")
+    monkeypatch.setattr(api_module, "chat", lambda **kw: "nope")
+
+    client = TestClient(api_module.app)
+    r = client.post("/message", json=IMAGE_PAYLOAD)
+    assert r.status_code == 200
+    assert r.json() == {"response": None}
+
+
+def test_message_text_calls_chat(monkeypatch):
+    import src.api as api_module
+    monkeypatch.setattr(api_module, "_WEBHOOK_SECRET", "")
+
+    captured = {}
+
+    def fake_chat(*, text, **kwargs):
+        captured["text"] = text
+        return "Givelight is an orphan aid programme."
+
+    monkeypatch.setattr(api_module, "chat", fake_chat)
+
+    client = TestClient(api_module.app)
+    r = client.post("/message", json=SAMPLE_TEXT_PAYLOAD)
+    assert r.status_code == 200
+    assert r.json() == {"response": "Givelight is an orphan aid programme."}
+    assert captured["text"] == "Hello B2, what is Givelight?"
+
+
+# ---------------------------------------------------------------------------
+# /message — secret header enforcement
+# ---------------------------------------------------------------------------
+
+def test_message_missing_secret_returns_401(monkeypatch):
+    import src.api as api_module
+    monkeypatch.setattr(api_module, "_WEBHOOK_SECRET", "mysecret")
+
+    client = TestClient(api_module.app, raise_server_exceptions=False)
+    r = client.post("/message", json=SAMPLE_TEXT_PAYLOAD)
+    assert r.status_code == 401
+
+
+def test_message_wrong_secret_returns_401(monkeypatch):
+    import src.api as api_module
+    monkeypatch.setattr(api_module, "_WEBHOOK_SECRET", "mysecret")
+
+    client = TestClient(api_module.app, raise_server_exceptions=False)
+    r = client.post(
+        "/message",
+        json=SAMPLE_TEXT_PAYLOAD,
+        headers={"X-Webhook-Secret": "wrongsecret"},
+    )
+    assert r.status_code == 401
+
+
+def test_message_correct_secret_passes(monkeypatch):
+    import src.api as api_module
+    monkeypatch.setattr(api_module, "_WEBHOOK_SECRET", "mysecret")
+    monkeypatch.setattr(api_module, "chat", lambda *, text, **kw: "ok")
+
+    client = TestClient(api_module.app)
+    r = client.post(
+        "/message",
+        json=SAMPLE_TEXT_PAYLOAD,
+        headers={"X-Webhook-Secret": "mysecret"},
+    )
+    assert r.status_code == 200
+    assert r.json()["response"] == "ok"

--- a/tests/unit/test_chat.py
+++ b/tests/unit/test_chat.py
@@ -77,6 +77,7 @@ def test_chat_routes_and_returns_streamed_text(monkeypatch) -> None:
             yield " there"
 
     monkeypatch.setattr(chat_module, "load_dotenv", lambda: None)
+    monkeypatch.setattr(chat_module, "_router", None)
     monkeypatch.setattr(chat_module, "AgentRouter", FakeRouter)
     monkeypatch.setattr(chat_module, "Session", FakeSession)
     monkeypatch.setattr(
@@ -123,6 +124,7 @@ def test_chat_loads_and_saves_stateful_history(monkeypatch) -> None:
             yield "hi"
 
     monkeypatch.setattr(chat_module, "load_dotenv", lambda: None)
+    monkeypatch.setattr(chat_module, "_router", None)
     monkeypatch.setattr(chat_module, "AgentRouter", FakeRouter)
     monkeypatch.setattr(chat_module, "Session", FakeSession)
     monkeypatch.setattr(chat_module, "FirestoreSessionStore", FakeStore)

--- a/tests/unit/test_embeddings.py
+++ b/tests/unit/test_embeddings.py
@@ -1,0 +1,103 @@
+"""Unit tests for src/embeddings.py — Vertex AI embedder."""
+
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+
+from src.embeddings import GoogleEmbedder, _DEFAULT_DIM, _DEFAULT_MODEL
+
+
+def _make_embedding(values: list[float]) -> MagicMock:
+    e = MagicMock()
+    e.values = values
+    return e
+
+
+def _fake_client(vectors: list[list[float]]) -> MagicMock:
+    response = MagicMock()
+    response.embeddings = [_make_embedding(v) for v in vectors]
+    client = MagicMock()
+    client.models.embed_content.return_value = response
+    return client
+
+
+@patch("src.embeddings.genai.Client")
+def test_init_uses_vertex_ai(mock_client_cls):
+    mock_client_cls.return_value = MagicMock()
+    GoogleEmbedder(project="my-project", location="us-east1")
+    mock_client_cls.assert_called_once_with(
+        vertexai=True,
+        project="my-project",
+        location="us-east1",
+    )
+
+
+@patch("src.embeddings.genai.Client")
+def test_init_reads_env_vars(mock_client_cls, monkeypatch):
+    monkeypatch.setenv("GOOGLE_CLOUD_PROJECT", "env-project")
+    monkeypatch.setenv("VERTEX_LOCATION", "us-central1")
+    mock_client_cls.return_value = MagicMock()
+    GoogleEmbedder()
+    mock_client_cls.assert_called_once_with(
+        vertexai=True,
+        project="env-project",
+        location="us-central1",
+    )
+
+
+@patch("src.embeddings.genai.Client")
+def test_init_no_api_key_required(mock_client_cls):
+    """No GEMINI_API_KEY env var should not raise."""
+    mock_client_cls.return_value = MagicMock()
+    embedder = GoogleEmbedder(project="p", location="l")
+    assert embedder.model == _DEFAULT_MODEL
+    assert embedder.output_dimensionality == _DEFAULT_DIM
+
+
+@patch("src.embeddings.genai.Client")
+def test_embed_documents_calls_retrieval_document(mock_client_cls):
+    client = _fake_client([[0.1] * 768, [0.2] * 768])
+    mock_client_cls.return_value = client
+
+    embedder = GoogleEmbedder(project="p", location="l")
+    result = embedder.embed_documents(["doc one", "doc two"])
+
+    assert result.shape == (2, 768)
+    call_kwargs = client.models.embed_content.call_args
+    assert call_kwargs.kwargs["config"].task_type == "RETRIEVAL_DOCUMENT"
+
+
+@patch("src.embeddings.genai.Client")
+def test_embed_query_calls_retrieval_query(mock_client_cls):
+    client = _fake_client([[0.5] * 768])
+    mock_client_cls.return_value = client
+
+    embedder = GoogleEmbedder(project="p", location="l")
+    result = embedder.embed_query("hello")
+
+    assert result.shape == (768,)
+    call_kwargs = client.models.embed_content.call_args
+    assert call_kwargs.kwargs["config"].task_type == "RETRIEVAL_QUERY"
+
+
+@patch("src.embeddings.genai.Client")
+def test_embed_documents_empty_input(mock_client_cls):
+    mock_client_cls.return_value = MagicMock()
+    embedder = GoogleEmbedder(project="p", location="l")
+    result = embedder.embed_documents([])
+    assert result.shape == (0, 768)
+    mock_client_cls.return_value.models.embed_content.assert_not_called()
+
+
+@patch("src.embeddings.genai.Client")
+def test_l2_normalisation(mock_client_cls):
+    raw = [3.0, 4.0] + [0.0] * 766
+    client = _fake_client([raw])
+    mock_client_cls.return_value = client
+
+    embedder = GoogleEmbedder(project="p", location="l", output_dimensionality=768)
+    result = embedder.embed_query("x")
+
+    norm = float(np.linalg.norm(result))
+    assert abs(norm - 1.0) < 1e-5


### PR DESCRIPTION
Before this PR, every WhatsApp message sent to the B2's Formal WhatsApp Number received the same static placeholder reply. This PR replaces that placeholder with a real AI response; the message reaches a Gemini agent, gets a meaningful reply, and the conversation is remembered across follow-up messages.

**How it works**

When someone sends a WhatsApp message, the central webhook in `benevolent-bandwidth` forwards it to a new Cloud Run service in `b2-platform` called `b2-whatsapp-adapter`. That service reads the message, determines which agent should handle it, and routes the text to a Gemini-powered agent. The agent's response is sent back to the webhook, which then delivers it to the user on WhatsApp.

The sender's WhatsApp number is used as a conversation key. Each time they write in, their previous messages are loaded before the agent responds, so the conversation feels continuous. Sessions expire after 72 hours of no activity.

No API keys are involved anywhere. The service authenticates with Google Cloud automatically through the service account attached to it.

**What's blocking it right now**

The service is deployed and ready, but it is currently running under the wrong Google Cloud identity. The one it has doesn't have permission to reach the Gemini models, which sit in the `benevolent-bandwidth` project. Google returns a "not found" error rather than a "permission denied" when this happens, which made it look like a model issue at first.

The fix requires one change in the GCP Console, no code: go to the Cloud Run service, edit the revision, and change the service account to `b2-platform-app-service@b2-platform.iam.gserviceaccount.com`. That gives it the right access, and the Gemini calls will go through.

**What's next**

- The `/message` endpoint currently has no caller verification: anyone who knows the URL can post to it. Before `benevolent-bandwidth` is updated to use this service, a shared secret should be agreed on, stored in Secret Manager on both sides, and sent as a request header on every call.

- Once the service account issue above is fixed, the Cloud Run URL needs to be shared with Eman Cickusic so the webhook can be switched from the placeholder reply to this service.

- The current agent handles everything: Givelight questions, document guidance, greetings, Arabic and French messages. As more specific agents are added (death certificate intake, application status), they will each get their own description, and the router will direct messages to the right one automatically.

**Testing**

22 unit tests, 0 failures. No real API calls are made during the test run. Covered: message extraction, routing, conversation history, session persistence, webhook secret checks, and the full request flow end-to-end.

```
pytest tests/unit/test_api.py tests/unit/test_chat.py tests/unit/test_session_store.py -q
# 22 passed
```
