### PR TITLE
Deployment Fixes: Cloud Build and Agent model names

### DIFF
--- a/agents/creativeAgent.yaml
+++ b/agents/creativeAgent.yaml
@@ -19,7 +19,7 @@ tools:
 
 provider:
   type: gemini
-  model: gemini-3.1-flash-lite-preview
+  model: gemini-2.5-flash
   settings:
     thinking_budget: 0
 

--- a/agents/exampleAgent.yaml
+++ b/agents/exampleAgent.yaml
@@ -16,7 +16,7 @@ tools:
 
 provider:
   type: gemini
-  model: gemini-3.1-flash-lite-preview
+  model: gemini-2.5-flash
   settings:
     thinking_budget: 0
 

--- a/agents/whatsapp_agent.yaml
+++ b/agents/whatsapp_agent.yaml
@@ -24,6 +24,6 @@ system_prompt: |
 
 provider:
   type: gemini
-  model: gemini-2.0-flash
+  model: gemini-2.5-flash
   settings:
     thinking_budget: 0

--- a/requirements-api.txt
+++ b/requirements-api.txt
@@ -6,7 +6,7 @@ fastapi>=0.115.0
 uvicorn[standard]>=0.30.0
 pydantic>=2.8.0
 pydantic-settings>=2.3.0
-pydantic-ai==1.98.0
+pydantic-ai-slim[google,vertexai]==1.98.0
 google-genai>=1.0.0
 google-cloud-firestore>=2.0.0
 numpy>=1.26.0

--- a/src/orchestrator/agent.py
+++ b/src/orchestrator/agent.py
@@ -14,7 +14,7 @@ from pydantic_ai import Agent as PydanticAgent
 from pydantic_ai.messages import ModelMessage, UserContent
 from pydantic_ai.models import Model
 from pydantic_ai.models.google import GoogleModel
-from pydantic_ai.providers.google import GoogleCloudProvider
+from pydantic_ai.providers.google import GoogleProvider
 
 from . import prompts, tools
 
@@ -147,7 +147,8 @@ class Agent:
         model_settings = cls._model_settings_from_provider(provider, model_name)
         model = GoogleModel(
             model_name,
-            provider=GoogleCloudProvider(
+            provider=GoogleProvider(
+                vertexai=True,
                 project=project,
                 location=location,
             ),

--- a/src/orchestrator/agent.py
+++ b/src/orchestrator/agent.py
@@ -14,7 +14,7 @@ from pydantic_ai import Agent as PydanticAgent
 from pydantic_ai.messages import ModelMessage, UserContent
 from pydantic_ai.models import Model
 from pydantic_ai.models.google import GoogleModel
-from pydantic_ai.providers.google import GoogleProvider
+from pydantic_ai.providers.google import GoogleCloudProvider
 
 from . import prompts, tools
 
@@ -147,8 +147,7 @@ class Agent:
         model_settings = cls._model_settings_from_provider(provider, model_name)
         model = GoogleModel(
             model_name,
-            provider=GoogleProvider(
-                vertexai=True,
+            provider=GoogleCloudProvider(
                 project=project,
                 location=location,
             ),


### PR DESCRIPTION
The previous build was failing before it even started. Installing `pydantic-ai` pulled in every optional add-on the package offers,  none of which we use. One of those add-ons, the logging library, had a version conflict that made pip give up entirely and refuse to build the image.

This PR swaps the full package for a slimmer version that only includes the two things we need: Google model support and Vertex AI. The build now completes cleanly.

**Agent model names**

Two background agents: an example agent and a creative writing agent, were configured to use a model called `gemini-3.1-flash-lite-preview`. That model does not exist. If the message router ever sent a conversation to either of those agents, the request would fail with a 404. Both have been updated to use `gemini-2.5-flash`, the same model the WhatsApp agent uses.

**Confirmed working end to end**

After these fixes were deployed, a test message: "Hello B2, what is Givelight?" was sent through Postman directly to the `/message` endpoint. The service returned a 200 with a real response from the agent in 16 seconds.

```
POST /message → 200 OK · 16.12 s
{ "response": "Hello! Givelight is our programme designed to provide support
  to orphans and vulnerable children. We focus on ensuring they have access
  to education, healthcare, and a nurturing environment. How can I help you
  with Givelight today?" }
```

**What was actually causing the 404**

An earlier theory pointed to an IAM permission as the blocker. Eman dug into it and confirmed that was not the case, a missing permission would return a 403, not a 404. The real issue was that `gemini-2.0-flash` has been retired on Vertex AI in `us-east1`. Google returns "Publisher model not found" for any request that names a retired model, regardless of who is asking. `gemini-2.5-flash` works with the same credentials and returns a 200.

The whatsapp agent was already updated to `gemini-2.5-flash` in a previous PR. This build confirms the fix is live and working. The service is ready. The remaining step is for the webhook in `benevolent-bandwidth` to be pointed at the Cloud Run URL so live WhatsApp messages start flowing through.
