### PR TITLE
Feat/e2e test platform

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ docs/
 
 # GCP credentials
 *.json
+!e2e_cases/**/*.json
 service-account*.json
 
 # IDE
@@ -27,6 +28,7 @@ Thumbs.db
 
 # Logs
 *.log
+e2e_runs/
 
 *.sqlite3
 
@@ -41,4 +43,3 @@ dummy/
 tools/fake_image_detector/local_samples/
 tools/fake_image_detector/models/
 tests/fixtures/dataset/
-

--- a/agents/creativeAgent.yaml
+++ b/agents/creativeAgent.yaml
@@ -19,7 +19,7 @@ tools:
 
 provider:
   type: gemini
-  model: gemini-3.1-flash-lite-preview
+  model: gemini-2.5-flash
   settings:
     thinking_budget: 0
 

--- a/agents/exampleAgent.yaml
+++ b/agents/exampleAgent.yaml
@@ -16,7 +16,7 @@ tools:
 
 provider:
   type: gemini
-  model: gemini-3.1-flash-lite-preview
+  model: gemini-2.5-flash
   settings:
     thinking_budget: 0
 

--- a/agents/whatsapp_agent.yaml
+++ b/agents/whatsapp_agent.yaml
@@ -24,6 +24,6 @@ system_prompt: |
 
 provider:
   type: gemini
-  model: gemini-2.0-flash
+  model: gemini-2.5-flash
   settings:
     thinking_budget: 0

--- a/e2e/__init__.py
+++ b/e2e/__init__.py
@@ -1,0 +1,2 @@
+"""POST-only e2e harness for the WhatsApp /message endpoint."""
+

--- a/e2e/assertions.py
+++ b/e2e/assertions.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from e2e.cases import Case
+
+Outcome = Literal["accept", "reject", "unknown"]
+TOOL_NAME = "death_certificate_verification"
+MISSING_TOOL_RESULT_ERROR = (
+    "--debug-tools requested but no death_certificate_verification tool result was returned; "
+    "check ENABLE_E2E_DEBUG and tool invocation"
+)
+
+DEFAULT_ACCEPT_INDICATORS = (
+    "forwarded to givelight",
+    "verification passed",
+    "verified",
+    "approved",
+    "accepted",
+    "eligible",
+)
+DEFAULT_REJECT_INDICATORS = (
+    "human review",
+    "did not meet",
+    "flagged",
+    "cannot verify",
+    "can't verify",
+    "no document",
+    "verification failed",
+    "not eligible",
+    "rejected",
+)
+
+
+def expected_outcome(expected: dict[str, Any]) -> Literal["accept", "reject"]:
+    configured = expected.get("expected_outcome")
+    if configured in {"accept", "reject"}:
+        return configured
+    if "should_pass" in expected:
+        return "accept" if bool(expected["should_pass"]) else "reject"
+    return "accept"
+
+
+def actual_outcome(
+    final_response: str,
+    expected: dict[str, Any],
+    tool_result: dict[str, Any] | None = None,
+    *,
+    allow_response_fallback: bool = True,
+) -> Outcome:
+    if tool_result is not None:
+        accepted = tool_result.get("accepted")
+        if accepted is True:
+            return "accept"
+        if accepted is False:
+            return "reject"
+        return "unknown"
+
+    if not allow_response_fallback:
+        return "unknown"
+
+    response = final_response.lower()
+    accept_indicators = _indicators(expected, "accept_indicators", DEFAULT_ACCEPT_INDICATORS)
+    reject_indicators = _indicators(expected, "reject_indicators", DEFAULT_REJECT_INDICATORS)
+
+    accept_match = any(indicator in response for indicator in accept_indicators)
+    reject_match = any(indicator in response for indicator in reject_indicators)
+    if accept_match == reject_match:
+        return "unknown"
+    return "accept" if accept_match else "reject"
+
+
+def classification(expected_value: str, actual_value: str) -> str:
+    if actual_value == "unknown":
+        return "UNKNOWN"
+    if expected_value == "accept" and actual_value == "accept":
+        return "TP"
+    if expected_value == "reject" and actual_value == "reject":
+        return "TN"
+    if expected_value == "reject" and actual_value == "accept":
+        return "FP"
+    if expected_value == "accept" and actual_value == "reject":
+        return "FN"
+    return "UNKNOWN"
+
+
+def assert_case(
+    case: Case,
+    turns: list[dict[str, Any]],
+    final_response: str,
+    *,
+    remote_media_error: str | None = None,
+    tool_result: dict[str, Any] | None = None,
+    require_tool_result: bool = False,
+) -> list[str]:
+    expected = case.expected
+    http_status = int(expected.get("http_status", 200))
+    min_response_chars = int(expected.get("min_response_chars", 1))
+    errors: list[str] = []
+
+    if remote_media_error:
+        errors.append(remote_media_error)
+
+    if require_tool_result and tool_result is None:
+        errors.append(MISSING_TOOL_RESULT_ERROR)
+
+    for turn in turns:
+        if turn["status_code"] != http_status:
+            errors.append(f"{turn['label']} HTTP {turn['status_code']} != expected {http_status}")
+
+    if len(final_response) < min_response_chars:
+        errors.append(f"final response has {len(final_response)} chars; expected at least {min_response_chars}")
+
+    for needle in expected.get("response_contains", []):
+        if str(needle) not in final_response:
+            errors.append(f"final response missing required substring: {needle!r}")
+
+    any_needles = [str(value) for value in expected.get("response_contains_any", [])]
+    if any_needles and not any(needle in final_response for needle in any_needles):
+        errors.append(f"final response missing any of: {any_needles!r}")
+
+    for needle in expected.get("response_not_contains", []):
+        if str(needle) in final_response:
+            errors.append(f"final response contains forbidden substring: {needle!r}")
+
+    expected_value = expected_outcome(expected)
+    actual_value = actual_outcome(
+        final_response,
+        expected,
+        tool_result,
+        allow_response_fallback=not require_tool_result,
+    )
+    if actual_value == "unknown":
+        errors.append("actual outcome is unknown; update indicators or inspect response")
+    elif actual_value != expected_value:
+        errors.append(f"actual outcome {actual_value!r} != expected {expected_value!r}")
+
+    return errors
+
+
+def latest_tool_result(turns: list[dict[str, Any]]) -> dict[str, Any] | None:
+    latest: dict[str, Any] | None = None
+    for turn in turns:
+        response_json = turn.get("response_json")
+        if not isinstance(response_json, dict):
+            continue
+        debug = response_json.get("debug")
+        if not isinstance(debug, dict):
+            continue
+        tool_results = debug.get("tool_results")
+        if not isinstance(tool_results, list):
+            continue
+        for result in tool_results:
+            if isinstance(result, dict) and result.get("tool") == TOOL_NAME:
+                latest = result
+    return latest
+
+
+def _indicators(expected: dict[str, Any], key: str, defaults: tuple[str, ...]) -> list[str]:
+    values = expected.get(key)
+    if values is None:
+        return list(defaults)
+    if not isinstance(values, list):
+        raise ValueError(f"{key} must be a list when provided")
+    return [str(value).lower() for value in values]

--- a/e2e/cases.py
+++ b/e2e/cases.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+CERTIFICATE_NAMES = ("certificate.png", "certificate.jpg", "certificate.jpeg", "certificate.pdf")
+MEDIA_EXTENSIONS = {".png", ".jpg", ".jpeg", ".pdf"}
+
+
+@dataclass(frozen=True)
+class Case:
+    country: str
+    kind: str
+    case_id: str
+    path: Path
+    narrative: str | None
+    certificate_path: Path | None
+    expected: dict[str, Any]
+
+    @property
+    def wa_id(self) -> str:
+        return f"e2e-{self.country}-{self.kind}-{self.case_id}"
+
+    @property
+    def label(self) -> str:
+        return f"{self.country}/{self.kind}/{self.case_id}"
+
+
+def discover_cases(root: Path, *, country: str | None, kind: str | None) -> list[Case]:
+    if not root.exists():
+        return []
+
+    cases: list[Case] = []
+    country_dirs = [root / country] if country else sorted(path for path in root.iterdir() if path.is_dir())
+    for country_dir in country_dirs:
+        if not country_dir.is_dir():
+            continue
+        kind_dirs = [country_dir / kind] if kind else [country_dir / "real", country_dir / "fake"]
+        for kind_dir in kind_dirs:
+            if not kind_dir.is_dir():
+                continue
+            for case_dir in sorted(path for path in kind_dir.iterdir() if path.is_dir()):
+                cases.append(load_case(root, case_dir))
+    return cases
+
+
+def load_case(root: Path, case_dir: Path) -> Case:
+    rel = case_dir.relative_to(root)
+    country, kind, case_id = rel.parts[:3]
+    narrative_path = case_dir / "narrative.txt"
+    expected_path = case_dir / "expected.json"
+
+    narrative = narrative_path.read_text(encoding="utf-8").strip() if narrative_path.exists() else None
+    expected = load_expected(expected_path)
+    certificate_path = find_certificate(case_dir)
+
+    return Case(
+        country=country,
+        kind=kind,
+        case_id=case_id,
+        path=case_dir,
+        narrative=narrative or None,
+        certificate_path=certificate_path,
+        expected=expected,
+    )
+
+
+def load_expected(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return {"expected_outcome": "accept"}
+    with path.open(encoding="utf-8") as handle:
+        data = json.load(handle)
+    if not isinstance(data, dict):
+        raise ValueError(f"{path} must contain a JSON object")
+    return data
+
+
+def find_certificate(case_dir: Path) -> Path | None:
+    named = [case_dir / name for name in CERTIFICATE_NAMES]
+    matches = [path for path in named if path.exists()]
+    if not matches:
+        matches = [
+            path
+            for path in sorted(case_dir.iterdir())
+            if path.is_file() and path.stem == "certificate" and path.suffix.lower() in MEDIA_EXTENSIONS
+        ]
+    if len(matches) > 1:
+        raise ValueError(f"{case_dir} has multiple certificate files")
+    return matches[0] if matches else None
+

--- a/e2e/local_app.py
+++ b/e2e/local_app.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import asyncio
+import threading
+import time
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+from e2e.payloads import mime_for_path
+
+
+class InMemoryStore:
+    """Stand-in for FirestoreSessionStore, shared across all local test turns."""
+
+    def __init__(self) -> None:
+        self._history: dict[str, list[Any]] = {}
+        self._media: dict[str, tuple[bytes, str]] = {}
+
+    def load_history(self, session_id: str) -> list[Any]:
+        return list(self._history.get(session_id, []))
+
+    def save_history(
+        self,
+        session_id: str,
+        history: list[Any],
+        *,
+        agent_name: str | None = None,
+        channel: str | None = None,
+    ) -> None:
+        self._history[session_id] = list(history)
+
+    def save_media(self, session_id: str, image_bytes: bytes, *, mime_type: str) -> bool:
+        self._media[session_id] = (image_bytes, mime_type)
+        return True
+
+    def load_latest_media(self, session_id: str) -> tuple[bytes, str] | None:
+        return self._media.get(session_id)
+
+
+def start_local_server(port: int, secret: str, *, debug_tools: bool = False) -> tuple[str, threading.Thread]:
+    from src import api as api_module
+    from src import chat as chat_module
+
+    shared_store = InMemoryStore()
+    media_by_id: dict[str, tuple[bytes, str]] = {}
+
+    async def fake_download(media_id: str) -> tuple[bytes, str] | None:
+        return media_by_id.get(media_id)
+
+    chat_module.FirestoreSessionStore = lambda *a, **k: shared_store  # type: ignore[assignment]
+    api_module.download_media = fake_download  # type: ignore[assignment]
+    api_module._WEBHOOK_SECRET = secret
+    if debug_tools:
+        api_module._ENABLE_E2E_DEBUG = "true"
+    api_module.app.state.e2e_media_by_id = media_by_id
+
+    def serve() -> None:
+        import uvicorn
+
+        config = uvicorn.Config(
+            api_module.app,
+            host="127.0.0.1",
+            port=port,
+            log_level="warning",
+            log_config=None,
+        )
+        server = uvicorn.Server(config)
+        server.install_signal_handlers = lambda: None
+        asyncio.run(server.serve())
+
+    thread = threading.Thread(target=serve, daemon=True)
+    thread.start()
+    return f"http://127.0.0.1:{port}", thread
+
+
+def wait_for_health(base_url: str, timeout: float) -> None:
+    deadline = time.monotonic() + min(timeout, 30.0)
+    with httpx.Client(timeout=5.0) as client:
+        while time.monotonic() < deadline:
+            try:
+                response = client.get(f"{base_url}/health")
+                if response.status_code == 200:
+                    return
+            except httpx.HTTPError:
+                pass
+            time.sleep(0.2)
+    raise RuntimeError(f"server did not become healthy at {base_url}")
+
+
+def register_local_media(media_id: str, certificate_path: Path) -> None:
+    from src import api as api_module
+
+    media_by_id = getattr(api_module.app.state, "e2e_media_by_id")
+    media_by_id[media_id] = (certificate_path.read_bytes(), mime_for_path(certificate_path))

--- a/e2e/payloads.py
+++ b/e2e/payloads.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import mimetypes
+import time
+from pathlib import Path
+from typing import Any
+
+
+def meta_text_payload(*, wa_id: str, body: str, message_id: str) -> dict[str, Any]:
+    return meta_payload(
+        wa_id=wa_id,
+        message={
+            "from": wa_id,
+            "id": message_id,
+            "timestamp": str(int(time.time())),
+            "type": "text",
+            "text": {"body": body},
+        },
+    )
+
+
+def meta_media_payload(
+    *,
+    wa_id: str,
+    media_id: str,
+    mime_type: str,
+    message_id: str,
+) -> dict[str, Any]:
+    media_type = "document" if mime_type == "application/pdf" else "image"
+    return meta_payload(
+        wa_id=wa_id,
+        message={
+            "from": wa_id,
+            "id": message_id,
+            "timestamp": str(int(time.time())),
+            "type": media_type,
+            media_type: {"id": media_id, "mime_type": mime_type},
+        },
+    )
+
+
+def meta_payload(*, wa_id: str, message: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "object": "whatsapp_business_account",
+        "entry": [
+            {
+                "id": "1745012400192435",
+                "changes": [
+                    {
+                        "value": {
+                            "messaging_product": "whatsapp",
+                            "metadata": {
+                                "display_phone_number": "16179164660",
+                                "phone_number_id": "1104821716055506",
+                            },
+                            "contacts": [{"profile": {"name": "E2E User"}, "wa_id": wa_id}],
+                            "messages": [message],
+                        },
+                        "field": "messages",
+                    }
+                ],
+            }
+        ],
+    }
+
+
+def mime_for_path(path: Path) -> str:
+    if path.suffix.lower() == ".pdf":
+        return "application/pdf"
+    guessed = mimetypes.guess_type(path.name)[0]
+    return guessed or "image/jpeg"
+

--- a/e2e/reports.py
+++ b/e2e/reports.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from e2e.stats import calculate_stats
+
+
+def write_reports(out_dir: Path, results: list[dict[str, Any]], base_url: str) -> tuple[Path, Path, dict[str, Any]]:
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S%fZ")
+    run_dir = out_dir / timestamp
+    run_dir.mkdir(parents=True, exist_ok=False)
+
+    passed = sum(1 for result in results if result["passed"])
+    report = {
+        "timestamp": timestamp,
+        "base_url": base_url,
+        "total": len(results),
+        "passed": passed,
+        "failed": len(results) - passed,
+        "stats": calculate_stats(results),
+        "results": results,
+    }
+    json_path = run_dir / "results.json"
+    md_path = run_dir / "summary.md"
+    json_path.write_text(json.dumps(report, indent=2), encoding="utf-8")
+    md_path.write_text(render_markdown(report), encoding="utf-8")
+    return json_path, md_path, report
+
+
+def render_markdown(report: dict[str, Any]) -> str:
+    lines = [
+        "# E2E Run Summary",
+        "",
+        f"- Base URL: `{report['base_url']}`",
+        f"- Total: {report['total']}",
+        f"- Passed: {report['passed']}",
+        f"- Failed: {report['failed']}",
+        "",
+        "## Stats",
+        "",
+        "| Scope | Total | Classified | Accuracy | FP | FN | Unknown |",
+        "| --- | ---: | ---: | ---: | ---: | ---: | ---: |",
+    ]
+    overall = report["stats"]["overall"]
+    lines.append(_stats_row("overall", overall))
+    for country, stats in report["stats"]["by_country"].items():
+        lines.append(_stats_row(country, stats))
+
+    lines.extend(
+        [
+            "",
+            "## Cases",
+            "",
+            "| Case | Result | Expected | Actual | Class | Final Response Chars | Errors |",
+            "| --- | --- | --- | --- | --- | ---: | --- |",
+        ]
+    )
+    for result in report["results"]:
+        status = "PASS" if result["passed"] else "FAIL"
+        errors = "<br>".join(result["errors"]) if result["errors"] else ""
+        lines.append(
+            f"| `{result['case']}` | {status} | {result['expected_outcome']} | "
+            f"{result['actual_outcome']} | {result['classification']} | "
+            f"{len(result['final_response'])} | {errors} |"
+        )
+    lines.append("")
+    return "\n".join(lines)
+
+
+def _stats_row(label: str, stats: dict[str, Any]) -> str:
+    return (
+        f"| `{label}` | {stats['total']} | {stats['classified']} | "
+        f"{_percent(stats['accuracy'])} | {stats['false_positives']} | "
+        f"{stats['false_negatives']} | {stats['unknown']} |"
+    )
+
+
+def _percent(value: float | None) -> str:
+    if value is None:
+        return "n/a"
+    return f"{value:.1%}"
+

--- a/e2e/runner.py
+++ b/e2e/runner.py
@@ -1,0 +1,172 @@
+from __future__ import annotations
+
+import time
+from typing import Any
+
+import httpx
+
+from e2e.assertions import actual_outcome, assert_case, classification, expected_outcome, latest_tool_result
+from e2e.cases import Case
+from e2e.local_app import register_local_media
+from e2e.payloads import meta_media_payload, meta_text_payload, mime_for_path
+
+
+def run_all(
+    cases: list[Case],
+    *,
+    base_url: str,
+    secret: str,
+    timeout: float,
+    local_mode: bool,
+    debug_tools: bool,
+) -> list[dict[str, Any]]:
+    results: list[dict[str, Any]] = []
+    with httpx.Client(timeout=timeout) as client:
+        for case in cases:
+            results.append(
+                run_case(
+                    client,
+                    case,
+                    base_url=base_url,
+                    secret=secret,
+                    local_mode=local_mode,
+                    debug_tools=debug_tools,
+                )
+            )
+    return results
+
+
+def run_case(
+    client: httpx.Client,
+    case: Case,
+    *,
+    base_url: str,
+    secret: str,
+    local_mode: bool,
+    debug_tools: bool,
+) -> dict[str, Any]:
+    headers = {"X-Webhook-Secret": secret} if secret else {}
+    if debug_tools:
+        headers["X-E2E-Debug"] = "true"
+    turns: list[dict[str, Any]] = []
+    skipped_turns: list[dict[str, str]] = []
+    errors: list[str] = []
+    final_response = ""
+    remote_media_error: str | None = None
+
+    if case.narrative:
+        payload = meta_text_payload(wa_id=case.wa_id, body=case.narrative, message_id=f"wamid.{case.wa_id}.text")
+        turn = post_turn(client, base_url, payload, headers, "narrative")
+        turns.append(turn)
+        final_response = response_body(turn)
+
+    media_id = case.expected.get("media_id")
+    if case.certificate_path and local_mode:
+        media_id = f"media-{case.country}-{case.kind}-{case.case_id}"
+        register_local_media(media_id, case.certificate_path)
+    elif case.certificate_path and not media_id:
+        remote_media_error = (
+            "remote mode cannot send local certificate without expected.json media_id; "
+            "media turn skipped"
+        )
+        skipped_turns.append({"label": "media", "reason": remote_media_error})
+
+    if media_id:
+        mime_type = str(case.expected.get("mime_type") or "image/jpeg")
+        if case.certificate_path and local_mode:
+            mime_type = mime_for_path(case.certificate_path)
+        payload = meta_media_payload(
+            wa_id=case.wa_id,
+            media_id=str(media_id),
+            mime_type=mime_type,
+            message_id=f"wamid.{case.wa_id}.media",
+        )
+        turn = post_turn(client, base_url, payload, headers, "media")
+        turns.append(turn)
+        final_response = response_body(turn)
+
+    if not turns:
+        errors.append("case produced no POST turns")
+
+    tool_result = latest_tool_result(turns)
+    missing_tool_result = debug_tools and tool_result is None
+    verdict_source = (
+        "tool_result"
+        if tool_result is not None
+        else "missing_tool_result"
+        if missing_tool_result
+        else "response_text"
+    )
+    errors.extend(
+        assert_case(
+            case,
+            turns,
+            final_response,
+            remote_media_error=remote_media_error,
+            tool_result=tool_result,
+            require_tool_result=debug_tools,
+        )
+    )
+    expected_value = expected_outcome(case.expected)
+    actual_value = (
+        "unknown"
+        if remote_media_error
+        else actual_outcome(
+            final_response,
+            case.expected,
+            tool_result,
+            allow_response_fallback=not missing_tool_result,
+        )
+    )
+    classified_as = classification(expected_value, actual_value)
+    passed = not errors and classified_as != "UNKNOWN"
+
+    return {
+        "case": case.label,
+        "country": case.country,
+        "kind": case.kind,
+        "case_id": case.case_id,
+        "wa_id": case.wa_id,
+        "path": str(case.path),
+        "expected": case.expected,
+        "expected_outcome": expected_value,
+        "actual_outcome": actual_value,
+        "classification": classified_as,
+        "verdict_source": verdict_source,
+        "tool_result": tool_result,
+        "turns": turns,
+        "skipped_turns": skipped_turns,
+        "final_response": final_response,
+        "errors": errors,
+        "passed": passed,
+    }
+
+
+def post_turn(
+    client: httpx.Client,
+    base_url: str,
+    payload: dict[str, Any],
+    headers: dict[str, str],
+    label: str,
+) -> dict[str, Any]:
+    started = time.perf_counter()
+    response = client.post(f"{base_url}/message", json=payload, headers=headers)
+    latency = time.perf_counter() - started
+    try:
+        response_json: Any = response.json()
+    except ValueError:
+        response_json = None
+    return {
+        "label": label,
+        "status_code": response.status_code,
+        "latency_seconds": round(latency, 3),
+        "response_json": response_json,
+        "response_text": response.text,
+    }
+
+
+def response_body(turn: dict[str, Any]) -> str:
+    response_json = turn.get("response_json")
+    if isinstance(response_json, dict) and response_json.get("response") is not None:
+        return str(response_json["response"])
+    return str(turn.get("response_text") or "")

--- a/e2e/stats.py
+++ b/e2e/stats.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+def calculate_stats(results: list[dict[str, Any]]) -> dict[str, Any]:
+    countries = sorted({str(result["country"]) for result in results})
+    by_country = {
+        country: _stats_for([result for result in results if result["country"] == country])
+        for country in countries
+    }
+    return {
+        "overall": _stats_for(results),
+        "by_country": by_country,
+    }
+
+
+def _stats_for(results: list[dict[str, Any]]) -> dict[str, Any]:
+    counts = {"TP": 0, "TN": 0, "FP": 0, "FN": 0, "UNKNOWN": 0}
+    for result in results:
+        cls = str(result.get("classification", "UNKNOWN"))
+        counts[cls if cls in counts else "UNKNOWN"] += 1
+
+    classified = counts["TP"] + counts["TN"] + counts["FP"] + counts["FN"]
+    total = classified + counts["UNKNOWN"]
+    accuracy = (counts["TP"] + counts["TN"]) / classified if classified else None
+    false_positive_rate = counts["FP"] / (counts["FP"] + counts["TN"]) if counts["FP"] + counts["TN"] else None
+    false_negative_rate = counts["FN"] / (counts["FN"] + counts["TP"]) if counts["FN"] + counts["TP"] else None
+
+    return {
+        "total": total,
+        "classified": classified,
+        "accuracy": accuracy,
+        "false_positives": counts["FP"],
+        "false_negatives": counts["FN"],
+        "false_positive_rate": false_positive_rate,
+        "false_negative_rate": false_negative_rate,
+        "unknown": counts["UNKNOWN"],
+        "tp": counts["TP"],
+        "tn": counts["TN"],
+        "fp": counts["FP"],
+        "fn": counts["FN"],
+    }
+

--- a/e2e_cases/README.md
+++ b/e2e_cases/README.md
@@ -1,0 +1,152 @@
+# E2E Cases
+
+Filesystem-driven cases for the POST-only `/message` e2e harness.
+
+The checked-in sample case uses fictional `example` country data only. Do not
+commit real certificates or real-person narratives as fixtures.
+
+## Layout
+
+```text
+e2e_cases/
+  <country>/
+    real/
+      <case_id>/
+        narrative.txt
+        certificate.png|certificate.jpg|certificate.jpeg|certificate.pdf
+        expected.json
+    fake/
+      <case_id>/
+        narrative.txt
+        expected.json
+```
+
+`narrative.txt`, `certificate.*`, and `expected.json` are optional, but each
+case should produce at least one `/message` POST. To test a certificate locally,
+drop a file named `certificate.png`, `certificate.jpg`, `certificate.jpeg`, or
+`certificate.pdf` into the case folder.
+
+## Expected JSON
+
+```json
+{
+  "expected_outcome": "accept",
+  "http_status": 200,
+  "min_response_chars": 1,
+  "accept_indicators": ["forwarded to GiveLight", "Verification passed"],
+  "reject_indicators": ["human review", "did not meet", "flagged"],
+  "response_contains": ["optional required text"],
+  "response_contains_any": ["one", "of these"],
+  "response_not_contains": ["forbidden text"]
+}
+```
+
+`expected_outcome` is either `accept` or `reject`. For older fixtures,
+`should_pass: true` maps to `accept`, and `should_pass: false` maps to `reject`.
+
+The preferred actual outcome source is the structured death-certificate tool
+result returned by `/message` debug mode. Enable it locally with:
+
+```bash
+uv run python scripts/e2e_cases.py --debug-tools
+```
+
+For deployed services, the Cloud Run service must also have:
+
+```text
+ENABLE_E2E_DEBUG=true
+```
+
+`--debug-tools` sends `X-E2E-Debug: true`. The API returns debug data only when
+both the header and environment gate are enabled.
+
+When tool debug output is present, the latest `death_certificate_verification`
+result drives metrics:
+
+```text
+accepted true  -> actual accept
+accepted false -> actual reject
+accepted null  -> unknown
+```
+
+Without tool debug output, the harness falls back to deriving the actual outcome
+from the final response body. Per-case `accept_indicators` and
+`reject_indicators` override the defaults. If neither side matches, or both
+sides match, the outcome is `unknown` and the case fails for metric purposes.
+
+Default accept indicators:
+
+```text
+forwarded to GiveLight
+Verification passed
+verified
+approved
+accepted
+eligible
+```
+
+Default reject indicators:
+
+```text
+human review
+did not meet
+flagged
+cannot verify
+can't verify
+no document
+verification failed
+not eligible
+rejected
+```
+
+## Stats
+
+Reports include overall and per-country stats:
+
+```text
+TP = expected accept + actual accept
+TN = expected reject + actual reject
+FP = expected reject + actual accept
+FN = expected accept + actual reject
+UNKNOWN = no clear actual outcome
+```
+
+Accuracy is `(TP + TN) / classified`, where classified excludes unknown cases.
+Unknown count is still reported.
+
+In remote `--base-url` mode, local certificate files are not uploaded. To send a
+media turn to a remote service, include a pre-existing Meta media ID:
+
+```json
+{
+  "expected_outcome": "accept",
+  "media_id": "meta-media-id",
+  "mime_type": "image/jpeg"
+}
+```
+
+If a case has a local certificate file and no `media_id`, remote mode marks the
+media turn skipped, fails the case, and classifies it as `UNKNOWN`. This avoids
+accidentally measuring a narrative-only request as a certificate test.
+
+## Commands
+
+Run locally against a uvicorn server started by the harness:
+
+```bash
+uv run python scripts/e2e_cases.py
+```
+
+Run against an existing deployed service:
+
+```bash
+uv run python scripts/e2e_cases.py --base-url https://example.run.app
+```
+
+Useful filters:
+
+```bash
+uv run python scripts/e2e_cases.py --country example --kind real
+```
+
+Reports are written under `e2e_runs/`.

--- a/e2e_cases/example/real/case_001/expected.json
+++ b/e2e_cases/example/real/case_001/expected.json
@@ -1,0 +1,5 @@
+{
+  "expected_outcome": "accept",
+  "http_status": 200,
+  "min_response_chars": 1
+}

--- a/e2e_cases/example/real/case_001/narrative.txt
+++ b/e2e_cases/example/real/case_001/narrative.txt
@@ -1,0 +1,1 @@
+Hello. This is a fictional e2e fixture from Exampleland. The claimant, Jordan Example, is submitting a fictional death certificate for their parent, Riley Sample, who passed away on 12 March 2025 in Sample City, Exampleland. This sample is non-real data for test harness structure only.

--- a/requirements-api.txt
+++ b/requirements-api.txt
@@ -6,7 +6,7 @@ fastapi>=0.115.0
 uvicorn[standard]>=0.30.0
 pydantic>=2.8.0
 pydantic-settings>=2.3.0
-pydantic-ai==1.98.0
+pydantic-ai-slim[google,vertexai]==1.98.0
 google-genai>=1.0.0
 google-cloud-firestore>=2.0.0
 numpy>=1.26.0

--- a/scripts/e2e_cases.py
+++ b/scripts/e2e_cases.py
@@ -1,0 +1,96 @@
+"""CLI entrypoint for the filesystem-driven /message e2e harness."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+# Make the repo root importable when run as `python scripts/e2e_cases.py`.
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+
+# Do not read local .env files when src.chat imports python-dotenv.
+os.environ.setdefault("PYTHON_DOTENV_DISABLED", "1")
+
+from e2e.cases import discover_cases
+from e2e.local_app import start_local_server, wait_for_health
+from e2e.reports import write_reports
+from e2e.runner import run_all
+
+DEFAULT_CASES_ROOT = "e2e_cases"
+DEFAULT_OUT_DIR = "e2e_runs"
+DEFAULT_PORT = 8765
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run filesystem-driven /message e2e cases.")
+    parser.add_argument("--base-url", help="Existing service URL. If omitted, starts local uvicorn.")
+    parser.add_argument("--cases-root", default=DEFAULT_CASES_ROOT)
+    parser.add_argument("--out-dir", default=DEFAULT_OUT_DIR)
+    parser.add_argument("--secret", default=os.getenv("WEBHOOK_SECRET", ""))
+    parser.add_argument("--timeout", type=float, default=120.0)
+    parser.add_argument("--country")
+    parser.add_argument("--kind", choices=("real", "fake"))
+    parser.add_argument("--port", type=int, default=DEFAULT_PORT, help="Local uvicorn port when --base-url is omitted.")
+    parser.add_argument(
+        "--debug-tools",
+        action="store_true",
+        help="Request structured tool debug output for verdict-based metrics.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    cases_root = (REPO_ROOT / args.cases_root).resolve()
+    out_dir = (REPO_ROOT / args.out_dir).resolve()
+    cases = discover_cases(cases_root, country=args.country, kind=args.kind)
+    if not cases:
+        print(f"No e2e cases found under {cases_root}")
+        return 1
+
+    local_mode = args.base_url is None
+    if local_mode:
+        base_url, _thread = start_local_server(args.port, args.secret, debug_tools=args.debug_tools)
+        wait_for_health(base_url, args.timeout)
+    else:
+        base_url = args.base_url.rstrip("/")
+
+    results = run_all(
+        cases,
+        base_url=base_url,
+        secret=args.secret,
+        timeout=args.timeout,
+        local_mode=local_mode,
+        debug_tools=args.debug_tools,
+    )
+    for result in results:
+        status = "PASS" if result["passed"] else "FAIL"
+        print(
+            f"{status} {result['case']} "
+            f"expected={result['expected_outcome']} actual={result['actual_outcome']} "
+            f"class={result['classification']} ({len(result['final_response'])} response chars)"
+        )
+        for error in result["errors"]:
+            print(f"  - {error}")
+
+    json_path, md_path, report = write_reports(out_dir, results, base_url)
+    failed = report["failed"]
+    stats = report["stats"]["overall"]
+    accuracy = stats["accuracy"]
+    accuracy_text = "n/a" if accuracy is None else f"{accuracy:.1%}"
+    print(f"\nSummary: {report['passed']}/{report['total']} passed, {failed} failed")
+    print(
+        "Stats: "
+        f"accuracy={accuracy_text}, FP={stats['false_positives']}, "
+        f"FN={stats['false_negatives']}, unknown={stats['unknown']}"
+    )
+    print(f"JSON: {json_path}")
+    print(f"Markdown: {md_path}")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/api.py
+++ b/src/api.py
@@ -22,9 +22,14 @@ logger = logging.getLogger(__name__)
 app = FastAPI(title="b2 WhatsApp Adapter")
 
 _WEBHOOK_SECRET = os.getenv("WEBHOOK_SECRET", "")
+_ENABLE_E2E_DEBUG = os.getenv("ENABLE_E2E_DEBUG", "")
 
 # WhatsApp media message types that carry a downloadable media ID.
 _MEDIA_TYPES = ("image", "document")
+
+
+def _truthy(value: str | None) -> bool:
+    return str(value or "").strip().lower() in {"1", "true", "yes", "on"}
 
 
 @dataclass
@@ -35,6 +40,20 @@ class InboundMessage:
     text: str | None = None
     media_id: str | None = None
     mime_type: str | None = None
+
+
+def _debug_response(
+    response: str | None,
+    message: InboundMessage,
+    debug_events: list[dict[str, Any]],
+) -> dict[str, Any]:
+    return {
+        "response": response,
+        "debug": {
+            "session_id": message.wa_id,
+            "tool_results": debug_events,
+        },
+    }
 
 
 def _extract_message(payload: dict[str, Any]) -> InboundMessage:
@@ -78,7 +97,8 @@ def _extract_message(payload: dict[str, Any]) -> InboundMessage:
 async def message_endpoint(
     request: Request,
     x_webhook_secret: str | None = Header(default=None),
-) -> dict[str, str | None]:
+    x_e2e_debug: str | None = Header(default=None),
+) -> dict[str, Any]:
     if _WEBHOOK_SECRET and x_webhook_secret != _WEBHOOK_SECRET:
         raise HTTPException(status_code=401, detail="Unauthorized")
 
@@ -86,11 +106,20 @@ async def message_endpoint(
     logger.info("api.message received object=%s", payload.get("object"))
 
     message = _extract_message(payload)
+    debug_enabled = _truthy(_ENABLE_E2E_DEBUG) and _truthy(x_e2e_debug)
+    debug_events: list[dict[str, Any]] | None = [] if debug_enabled else None
 
     if message.text is not None:
         logger.info("api.message routing text wa_id=%s chars=%d", message.wa_id, len(message.text))
-        response = await run_in_threadpool(chat, text=message.text, session_id=message.wa_id)
+        response = await run_in_threadpool(
+            chat,
+            text=message.text,
+            session_id=message.wa_id,
+            debug_events=debug_events,
+        )
         logger.info("api.message done wa_id=%s response_chars=%d", message.wa_id, len(response))
+        if debug_enabled:
+            return _debug_response(response, message, debug_events or [])
         return {"response": response}
 
     if message.media_id is not None:
@@ -98,6 +127,8 @@ async def message_endpoint(
         media = await download_media(message.media_id)
         if media is None:
             logger.info("api.message skipped — media download unavailable")
+            if debug_enabled:
+                return _debug_response(None, message, debug_events or [])
             return {"response": None}
         image_bytes, mime_type = media
         response = await run_in_threadpool(
@@ -105,11 +136,16 @@ async def message_endpoint(
             image_bytes=image_bytes,
             image_media_type=mime_type,
             session_id=message.wa_id,
+            debug_events=debug_events,
         )
         logger.info("api.message done wa_id=%s response_chars=%d", message.wa_id, len(response))
+        if debug_enabled:
+            return _debug_response(response, message, debug_events or [])
         return {"response": response}
 
     logger.info("api.message skipped — no actionable payload")
+    if debug_enabled:
+        return _debug_response(None, message, debug_events or [])
     return {"response": None}
 
 

--- a/src/chat.py
+++ b/src/chat.py
@@ -60,6 +60,7 @@ def chat(
     image_media_type: str = DEFAULT_IMAGE_MEDIA_TYPE,
     session_id: str | None = None,
     channel: str = "whatsapp",
+    debug_events: list[dict[str, object]] | None = None,
 ) -> str:
     """Route one WhatsApp text or image message through the agent loop and return the response."""
 
@@ -79,7 +80,12 @@ def chat(
 
     router = _get_router()
     agent, _metadata = router.route_with_metadata(route_query)
-    deps = SessionContext(session_id=session_id, store=store, history_text=history_text)
+    deps = SessionContext(
+        session_id=session_id,
+        store=store,
+        history_text=history_text,
+        debug_events=debug_events,
+    )
     session = Session(agent, history=history, deps=deps)
 
     response = "".join(session.send_stream(prompt))

--- a/src/orchestrator/agent.py
+++ b/src/orchestrator/agent.py
@@ -14,7 +14,7 @@ from pydantic_ai import Agent as PydanticAgent
 from pydantic_ai.messages import ModelMessage, UserContent
 from pydantic_ai.models import Model
 from pydantic_ai.models.google import GoogleModel
-from pydantic_ai.providers.google import GoogleCloudProvider
+from pydantic_ai.providers.google import GoogleProvider
 
 from . import prompts, tools
 
@@ -147,7 +147,8 @@ class Agent:
         model_settings = cls._model_settings_from_provider(provider, model_name)
         model = GoogleModel(
             model_name,
-            provider=GoogleCloudProvider(
+            provider=GoogleProvider(
+                vertexai=True,
                 project=project,
                 location=location,
             ),

--- a/src/orchestrator/agent.py
+++ b/src/orchestrator/agent.py
@@ -14,7 +14,7 @@ from pydantic_ai import Agent as PydanticAgent
 from pydantic_ai.messages import ModelMessage, UserContent
 from pydantic_ai.models import Model
 from pydantic_ai.models.google import GoogleModel
-from pydantic_ai.providers.google import GoogleProvider
+from pydantic_ai.providers.google import GoogleCloudProvider
 
 from . import prompts, tools
 
@@ -147,8 +147,7 @@ class Agent:
         model_settings = cls._model_settings_from_provider(provider, model_name)
         model = GoogleModel(
             model_name,
-            provider=GoogleProvider(
-                vertexai=True,
+            provider=GoogleCloudProvider(
                 project=project,
                 location=location,
             ),

--- a/src/orchestrator/context.py
+++ b/src/orchestrator/context.py
@@ -20,3 +20,4 @@ class SessionContext:
     session_id: str | None = None
     store: Any | None = None          # FirestoreSessionStore (history + media)
     history_text: str = ""            # rendered prior conversation, used as narrative
+    debug_events: list[dict[str, Any]] | None = None

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -252,6 +252,74 @@ def test_message_text_calls_chat(monkeypatch):
     assert captured["session_id"] == "16508106640"
 
 
+def test_message_text_debug_requires_env_and_header(monkeypatch):
+    import src.api as api_module
+    monkeypatch.setattr(api_module, "_WEBHOOK_SECRET", "")
+    monkeypatch.setattr(api_module, "_ENABLE_E2E_DEBUG", "true")
+
+    captured = {}
+
+    def fake_chat(*, text, session_id, debug_events=None, **kwargs):
+        captured["debug_events"] = debug_events
+        return "ok"
+
+    monkeypatch.setattr(api_module, "chat", fake_chat)
+
+    client = TestClient(api_module.app)
+    r = client.post("/message", json=SAMPLE_TEXT_PAYLOAD)
+    assert r.status_code == 200
+    assert r.json() == {"response": "ok"}
+    assert captured["debug_events"] is None
+
+
+def test_message_text_debug_returns_tool_results(monkeypatch):
+    import src.api as api_module
+    monkeypatch.setattr(api_module, "_WEBHOOK_SECRET", "")
+    monkeypatch.setattr(api_module, "_ENABLE_E2E_DEBUG", "yes")
+
+    def fake_chat(*, text, session_id, debug_events=None, **kwargs):
+        assert debug_events == []
+        debug_events.append(
+            {
+                "tool": "death_certificate_verification",
+                "status": "verified",
+                "score": 91,
+                "band": "high",
+                "accepted": True,
+                "handed_off": True,
+                "flags": [],
+                "extracted_fields": {"full_name": "Jane Doe"},
+                "summary": "Verification passed.",
+            }
+        )
+        return "ok"
+
+    monkeypatch.setattr(api_module, "chat", fake_chat)
+
+    client = TestClient(api_module.app)
+    r = client.post("/message", json=SAMPLE_TEXT_PAYLOAD, headers={"X-E2E-Debug": "true"})
+    assert r.status_code == 200
+    assert r.json() == {
+        "response": "ok",
+        "debug": {
+            "session_id": "16508106640",
+            "tool_results": [
+                {
+                    "tool": "death_certificate_verification",
+                    "status": "verified",
+                    "score": 91,
+                    "band": "high",
+                    "accepted": True,
+                    "handed_off": True,
+                    "flags": [],
+                    "extracted_fields": {"full_name": "Jane Doe"},
+                    "summary": "Verification passed.",
+                }
+            ],
+        },
+    }
+
+
 # ---------------------------------------------------------------------------
 # /message — secret header enforcement
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_chat.py
+++ b/tests/unit/test_chat.py
@@ -154,6 +154,36 @@ def test_chat_loads_and_saves_stateful_history(monkeypatch) -> None:
     }
 
 
+def test_chat_threads_debug_events_into_session_context(monkeypatch) -> None:
+    debug_events = []
+    captured = {}
+
+    class FakeRouter:
+        def route_with_metadata(self, query: str):
+            return object(), {"score": 1.0}
+
+    class FakeSession:
+        def __init__(self, agent: object, history=None, deps=None):
+            captured["deps"] = deps
+            self.history = []
+
+        def send_stream(self, prompt: str):
+            yield "ok"
+
+    monkeypatch.setattr(chat_module, "load_dotenv", lambda: None)
+    monkeypatch.setattr(chat_module, "_router", None)
+    monkeypatch.setattr(chat_module, "AgentRouter", FakeRouter)
+    monkeypatch.setattr(chat_module, "Session", FakeSession)
+    monkeypatch.setattr(
+        chat_module,
+        "FirestoreSessionStore",
+        lambda: (_ for _ in ()).throw(AssertionError("store should not be used")),
+    )
+
+    assert chat(text="hello", debug_events=debug_events) == "ok"
+    assert captured["deps"].debug_events is debug_events
+
+
 def test_render_history_text_flattens_user_and_assistant_turns() -> None:
     history = [
         ModelRequest(parts=[UserPromptPart(content="my mother passed away")]),

--- a/tests/unit/tools/death_certificate_pipeline/test_verify.py
+++ b/tests/unit/tools/death_certificate_pipeline/test_verify.py
@@ -15,9 +15,14 @@ class FakeStore:
         return self._media
 
 
-def _ctx(store, history_text="my mother Jane Doe passed away", session_id="wa-123"):
+def _ctx(store, history_text="my mother Jane Doe passed away", session_id="wa-123", debug_events=None):
     return SimpleNamespace(
-        deps=SimpleNamespace(session_id=session_id, store=store, history_text=history_text)
+        deps=SimpleNamespace(
+            session_id=session_id,
+            store=store,
+            history_text=history_text,
+            debug_events=debug_events,
+        )
     )
 
 
@@ -89,3 +94,34 @@ async def test_verify_reports_no_document_when_store_empty(monkeypatch):
 
     assert result["status"] == "no_document"
     assert result["handed_off"] is False
+
+
+async def test_verify_appends_debug_event(monkeypatch):
+    async def fake_pipeline(submission):
+        return _result(Band.MEDIUM)
+
+    async def fake_deliver(payload):
+        return False
+
+    monkeypatch.setattr(verify_module, "run_pipeline", fake_pipeline)
+    monkeypatch.setattr(verify_module, "deliver_to_gl", fake_deliver)
+
+    debug_events = []
+    result = await verify_death_certificate(
+        _ctx(FakeStore((b"\xff\xd8jpeg", "image/jpeg")), debug_events=debug_events)
+    )
+
+    assert result["status"] == "verified"
+    assert debug_events == [
+        {
+            "tool": "death_certificate_verification",
+            "status": "verified",
+            "score": 80,
+            "band": "medium",
+            "accepted": True,
+            "handed_off": False,
+            "flags": [],
+            "extracted_fields": {"full_name": "Jane Doe"},
+            "summary": result["summary"],
+        }
+    ]

--- a/tools/death_certificate_pipeline/verify.py
+++ b/tools/death_certificate_pipeline/verify.py
@@ -40,6 +40,25 @@ def _accepted(result: ReliabilityResult) -> bool:
     return result.band in _ACCEPT_BANDS and "HARD_ESCALATION" not in result.flags
 
 
+def _append_debug_event(deps: Any, payload: dict[str, Any], accepted: bool | None) -> None:
+    debug_events = getattr(deps, "debug_events", None)
+    if debug_events is None:
+        return
+    debug_events.append(
+        {
+            "tool": "death_certificate_verification",
+            "status": payload.get("status"),
+            "score": payload.get("score"),
+            "band": payload.get("band"),
+            "accepted": accepted,
+            "handed_off": bool(payload.get("handed_off", False)),
+            "flags": list(payload.get("flags", [])),
+            "extracted_fields": dict(payload.get("extracted_fields", {})),
+            "summary": str(payload.get("summary", "")),
+        }
+    )
+
+
 async def verify_death_certificate(ctx: Any) -> dict[str, Any]:
     """Verify the user's most recent document and hand off to GiveLight if it passes."""
     deps = getattr(ctx, "deps", None)
@@ -49,11 +68,13 @@ async def verify_death_certificate(ctx: Any) -> dict[str, Any]:
     media = store.load_latest_media(session_id) if (store is not None and session_id) else None
     if media is None:
         logger.info("verify.no_media session=%.8s", str(session_id or ""))
-        return {
+        payload = {
             "status": "no_document",
             "handed_off": False,
             "summary": "No document has been received yet — ask the user to send a photo or PDF of the death certificate.",
         }
+        _append_debug_event(deps, payload, accepted=None)
+        return payload
 
     image_bytes, _mime = media
     narrative = (getattr(deps, "history_text", "") or "").strip() or _NARRATIVE_FALLBACK
@@ -67,7 +88,8 @@ async def verify_death_certificate(ctx: Any) -> dict[str, Any]:
     result = await run_pipeline(submission)
     handed_off = False
 
-    if _accepted(result):
+    accepted = _accepted(result)
+    if accepted:
         payload = build_handoff_payload(
             result,
             contact_identifier=_contact_identifier(session_id),
@@ -80,11 +102,11 @@ async def verify_death_certificate(ctx: Any) -> dict[str, Any]:
         str(session_id or ""),
         result.score,
         result.band.value,
-        _accepted(result),
+        accepted,
         handed_off,
     )
 
-    return {
+    payload = {
         "status": "verified",
         "score": result.score,
         "band": result.band.value,
@@ -98,3 +120,5 @@ async def verify_death_certificate(ctx: Any) -> dict[str, Any]:
             "Consider asking the user for a clearer photo of the full certificate."
         ),
     }
+    _append_debug_event(deps, payload, accepted=accepted)
+    return payload


### PR DESCRIPTION
## Summary

Adds a POST-only e2e harness for `/message` that measures death-certificate verification outcomes by country.

The harness keeps `/message` as the exercised integration surface, but uses structured debug tool output for metrics instead of parsing the agent’s natural-language response.

## What changed

- Added `scripts/e2e_cases.py` CLI runner.
- Added filesystem fixture layout under `e2e_cases/<country>/<real|fake>/<case_id>/`.
- Added e2e package modules for case discovery, WhatsApp payload construction, local app stubbing, assertions, stats, and reports.
- Added per-country and overall TP/TN/FP/FN metrics.
- Added gated e2e debug output from `/message`.

## Debug verdict mode

`/message` keeps the normal production response shape unless both gates are enabled:

```text
ENABLE_E2E_DEBUG=true
X-E2E-Debug: true