### PR TITLE
Add e2e automation and fake certificate fixtures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,5 +56,8 @@ run_live_gemini_test_plan*
 # Death Certificates
 tests/test_dc/*
 !tests/test_dc/README.md
+e2e_cases/example/fake/*
+!e2e_cases/example/fake/case_000
+
 
 

--- a/README.md
+++ b/README.md
@@ -462,6 +462,95 @@ b2-platform/
 
 ---
 
+## End-to-End Test Automation
+
+The e2e harness runs filesystem-driven WhatsApp `/message` cases from
+`e2e_cases/` and writes machine-readable reports under `e2e_runs/`.
+When `--kind` is omitted, the harness discovers both `real/` and `fake/` case
+folders.
+
+The automation scripts added under `tests/scripts/` wrap that harness for local
+and remote runs:
+
+```bash
+tests/scripts/run_e2e_suite.sh
+```
+
+This command:
+
+1. Creates or reuses `.venv-testplan`.
+2. Installs `requirements-api.txt`, `pytest`, and `pytest-asyncio`.
+3. Enables `ENABLE_E2E_DEBUG=true` for the local harness process.
+4. Runs `scripts/e2e_cases.py --debug-tools` locally.
+5. Finds the newest `e2e_runs/local/*/results.json`.
+6. Gates the report with `tests/scripts/check_e2e_report.py`, including
+   separate `real` and `fake` summaries.
+
+The local runner restores the previous `ENABLE_E2E_DEBUG` value when it exits.
+If the variable was not set before the run, it unsets it.
+
+If `.env` exists, the e2e scripts load it automatically before running. To run
+without loading `.env`, set `E2E_LOAD_ENV=0`:
+
+```bash
+E2E_LOAD_ENV=0 tests/scripts/run_e2e_suite.sh
+```
+
+Useful local filters are passed through to the underlying harness:
+
+```bash
+tests/scripts/run_e2e_suite.sh --country example --kind real
+```
+
+Run all real and fake cases for a country:
+
+```bash
+tests/scripts/run_e2e_suite.sh --country example
+```
+
+Run only the local harness wrapper:
+
+```bash
+tests/scripts/run_e2e_local.sh
+```
+
+Gate an existing report:
+
+```bash
+python tests/scripts/check_e2e_report.py e2e_runs/local/<timestamp>/results.json
+```
+
+By default, the report gate fails when:
+
+- Any e2e case fails.
+- Any classified case is missing a structured tool verdict.
+- Any case is classified as `UNKNOWN`.
+- Any false positive is reported.
+
+Optional thresholds:
+
+```bash
+python tests/scripts/check_e2e_report.py e2e_runs/local/<timestamp>/results.json \
+  --max-unknown 0 \
+  --max-fp 0 \
+  --max-fn 1 \
+  --min-accuracy 0.95
+```
+
+Remote non-production smoke tests require a deployed service URL:
+
+```bash
+BASE_URL=https://example.run.app WEBHOOK_SECRET=... tests/scripts/run_e2e_remote.sh
+```
+
+Remote structured verdicts require `ENABLE_E2E_DEBUG=true` on the deployed
+service. Remote media cases also need a pre-existing Meta media ID in each
+case's `expected.json`; local certificate files are not uploaded in remote mode.
+
+Do not commit real certificates or real-person narratives as e2e fixtures.
+
+---
+
 ## Contributing
 
 We are actively looking for contributors to own MVP components.

--- a/e2e_cases/example/fake/case_000/expected.json
+++ b/e2e_cases/example/fake/case_000/expected.json
@@ -1,0 +1,5 @@
+{
+  "expected_outcome": "reject",
+  "http_status": 200,
+  "min_response_chars": 1
+}

--- a/e2e_cases/example/fake/case_000/narrative.txt
+++ b/e2e_cases/example/fake/case_000/narrative.txt
@@ -1,0 +1,1 @@
+Hello. This is a fictional e2e fixture from Exampleland. The claimant, Jordan Example, is submitting a fictional death certificate for their parent, Riley Sample, who passed away on 12 March 2025 in Sample City, Exampleland. This sample is non-real data for test harness structure only.

--- a/scripts/e2e_cases.py
+++ b/scripts/e2e_cases.py
@@ -42,6 +42,81 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
+def run_all(
+    cases,
+    *,
+    base_url: str,
+    secret: str,
+    timeout: float,
+    local_mode: bool,
+    debug_tools: bool,
+):
+    import httpx
+
+    from e2e.runner import run_case
+
+    results = []
+    total = len(cases)
+    with httpx.Client(timeout=timeout) as client:
+        for index, case in enumerate(cases, start=1):
+            _print_progress(index, total, case.label)
+            result = run_case(
+                client,
+                case,
+                base_url=base_url,
+                secret=secret,
+                local_mode=local_mode,
+                debug_tools=debug_tools,
+            )
+            results.append(result)
+            _clear_progress_line()
+            print(_format_realtime_result(result))
+            for error in result["errors"]:
+                print(f"  - {error}")
+    return results
+
+
+def _format_realtime_result(result: dict) -> str:
+    status = _green("PASS") if result["passed"] else _red("FAIL")
+    return (
+        f"{status} {result['case']} "
+        f"expected={result['expected_outcome']} actual={result['actual_outcome']} "
+        f"class={result['classification']} ({len(result['final_response'])} response chars)"
+    )
+
+
+def _progress_bar(done: int, total: int, width: int = 28) -> str:
+    if total <= 0:
+        return "[----------------------------] 0/0 0%"
+    filled = round(width * done / total)
+    bar = "#" * filled + "-" * (width - filled)
+    percent = round(100 * done / total)
+    return f"[{bar}] {done}/{total} {percent}%"
+
+
+def _print_progress(index: int, total: int, label: str) -> None:
+    text = f"{_progress_bar(index - 1, total)} RUNNING {index}/{total} {label}"
+    print(f"\r{text}", end="", flush=True)
+
+
+def _clear_progress_line() -> None:
+    print("\r\033[2K", end="", flush=True)
+
+
+def _green(value: str) -> str:
+    return _color(value, "32")
+
+
+def _red(value: str) -> str:
+    return _color(value, "31")
+
+
+def _color(value: str, code: str) -> str:
+    if os.getenv("NO_COLOR"):
+        return value
+    return f"\033[{code}m{value}\033[0m"
+
+
 def main() -> int:
     args = parse_args()
     cases_root = (REPO_ROOT / args.cases_root).resolve()
@@ -66,6 +141,9 @@ def main() -> int:
         local_mode=local_mode,
         debug_tools=args.debug_tools,
     )
+    print()
+    print("=" * 80)
+    print()
     for result in results:
         status = "PASS" if result["passed"] else "FAIL"
         print(
@@ -81,6 +159,9 @@ def main() -> int:
     stats = report["stats"]["overall"]
     accuracy = stats["accuracy"]
     accuracy_text = "n/a" if accuracy is None else f"{accuracy:.1%}"
+    
+    print()
+    print("=" * 80)
     print(f"\nSummary: {report['passed']}/{report['total']} passed, {failed} failed")
     print(
         "Stats: "

--- a/tests/scripts/check_e2e_report.py
+++ b/tests/scripts/check_e2e_report.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""Gate an e2e harness results.json report for automated testing."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Validate an e2e harness results.json report.")
+    parser.add_argument("report", type=Path, help="Path to e2e_runs/<timestamp>/results.json")
+    parser.add_argument("--max-unknown", type=int, default=0)
+    parser.add_argument("--max-fp", type=int, default=0, help="Maximum false positives allowed.")
+    parser.add_argument("--max-fn", type=int, default=None, help="Maximum false negatives allowed.")
+    parser.add_argument("--min-accuracy", type=float, default=None, help="Minimum classified accuracy, e.g. 0.95.")
+    parser.add_argument(
+        "--require-tool-result",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Require each classified case to use the structured death-certificate tool verdict.",
+    )
+    parser.add_argument(
+        "--allow-response-text",
+        action="store_true",
+        help="Allow response-text verdict fallback by disabling the structured verdict requirement.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    if args.allow_response_text:
+        args.require_tool_result = False
+
+    report = load_report(args.report)
+    stats = report.get("stats", {}).get("overall", {})
+    results = list(report.get("results") or [])
+    failures = collect_failures(report, stats, results, args)
+
+    print_summary(args.report, report, stats, results)
+    if failures:
+        print("\nE2E report gate failed:", file=sys.stderr)
+        for failure in failures:
+            print(f"- {failure}", file=sys.stderr)
+        return 1
+
+    print("\nE2E report gate passed.")
+    return 0
+
+
+def load_report(path: Path) -> dict[str, Any]:
+    if not path.is_file():
+        print(f"FAIL: report file not found: {path}", file=sys.stderr)
+        raise SystemExit(1)
+    with path.open(encoding="utf-8") as handle:
+        data = json.load(handle)
+    if not isinstance(data, dict):
+        print(f"FAIL: report must contain a JSON object: {path}", file=sys.stderr)
+        raise SystemExit(1)
+    return data
+
+
+def collect_failures(
+    report: dict[str, Any],
+    stats: dict[str, Any],
+    results: list[dict[str, Any]],
+    args: argparse.Namespace,
+) -> list[str]:
+    failures: list[str] = []
+    failed = int(report.get("failed") or 0)
+    unknown = int(stats.get("unknown") or 0)
+    false_positives = int(stats.get("false_positives") or 0)
+    false_negatives = int(stats.get("false_negatives") or 0)
+    accuracy = stats.get("accuracy")
+
+    if failed:
+        failures.append(f"report has {failed} failed case(s)")
+    if unknown > args.max_unknown:
+        failures.append(f"unknown={unknown} exceeds max_unknown={args.max_unknown}")
+    if false_positives > args.max_fp:
+        failures.append(f"false_positives={false_positives} exceeds max_fp={args.max_fp}")
+    if args.max_fn is not None and false_negatives > args.max_fn:
+        failures.append(f"false_negatives={false_negatives} exceeds max_fn={args.max_fn}")
+    if args.min_accuracy is not None:
+        if accuracy is None:
+            failures.append("accuracy is n/a and cannot satisfy min_accuracy")
+        elif float(accuracy) < args.min_accuracy:
+            failures.append(f"accuracy={float(accuracy):.3f} is below min_accuracy={args.min_accuracy:.3f}")
+
+    if args.require_tool_result:
+        for result in results:
+            if result.get("classification") == "UNKNOWN":
+                continue
+            if result.get("verdict_source") != "tool_result":
+                failures.append(
+                    f"{result.get('case', '<unknown>')} verdict_source={result.get('verdict_source')!r}; "
+                    "expected 'tool_result'"
+                )
+            if not isinstance(result.get("tool_result"), dict):
+                failures.append(f"{result.get('case', '<unknown>')} is missing structured tool_result")
+
+    for result in results:
+        errors = result.get("errors") or []
+        if errors:
+            failures.append(f"{result.get('case', '<unknown>')} errors: {'; '.join(map(str, errors))}")
+
+    return failures
+
+
+def print_summary(
+    path: Path,
+    report: dict[str, Any],
+    stats: dict[str, Any],
+    results: list[dict[str, Any]],
+) -> None:
+    accuracy = stats.get("accuracy")
+    accuracy_text = "n/a" if accuracy is None else f"{float(accuracy):.1%}"
+    print(f"Report: {path}")
+    print(f"Total: {report.get('total', len(results))}")
+    print(f"Passed: {report.get('passed', 0)}")
+    print(f"Failed: {report.get('failed', 0)}")
+    print(
+        "Stats: "
+        f"accuracy={accuracy_text}, "
+        f"FP={stats.get('false_positives', 0)}, "
+        f"FN={stats.get('false_negatives', 0)}, "
+        f"unknown={stats.get('unknown', 0)}"
+    )
+    print_group_summary("By kind", group_by(results, "kind"))
+    print_group_summary("By country/kind", group_by_country_kind(results))
+
+
+def group_by(results: list[dict[str, Any]], key: str) -> dict[str, list[dict[str, Any]]]:
+    groups: dict[str, list[dict[str, Any]]] = {}
+    for result in results:
+        groups.setdefault(str(result.get(key) or "unknown"), []).append(result)
+    return dict(sorted(groups.items()))
+
+
+def group_by_country_kind(results: list[dict[str, Any]]) -> dict[str, list[dict[str, Any]]]:
+    groups: dict[str, list[dict[str, Any]]] = {}
+    for result in results:
+        country = str(result.get("country") or "unknown")
+        kind = str(result.get("kind") or "unknown")
+        groups.setdefault(f"{country}/{kind}", []).append(result)
+    return dict(sorted(groups.items()))
+
+
+def print_group_summary(label: str, groups: dict[str, list[dict[str, Any]]]) -> None:
+    if not groups:
+        return
+    print(f"\n{label}:")
+    print("Scope | Total | Passed | Failed | TP | TN | FP | FN | Unknown")
+    print("--- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---:")
+    for scope, results in groups.items():
+        counts = {"TP": 0, "TN": 0, "FP": 0, "FN": 0, "UNKNOWN": 0}
+        for result in results:
+            classification = str(result.get("classification") or "UNKNOWN")
+            counts[classification if classification in counts else "UNKNOWN"] += 1
+        passed = sum(1 for result in results if result.get("passed"))
+        failed = len(results) - passed
+        print(
+            f"{scope} | {len(results)} | {passed} | {failed} | "
+            f"{counts['TP']} | {counts['TN']} | {counts['FP']} | "
+            f"{counts['FN']} | {counts['UNKNOWN']}"
+        )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scripts/run_e2e_local.sh
+++ b/tests/scripts/run_e2e_local.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+VENV_DIR="${ROOT_DIR}/.venv-testplan"
+PYTHON_BIN="${VENV_DIR}/bin/python"
+OUT_DIR="${E2E_OUT_DIR:-e2e_runs/local}"
+
+cd "$ROOT_DIR"
+
+if [[ "${E2E_LOAD_ENV:-1}" != "0" && -f "${ROOT_DIR}/.env" ]]; then
+  set -a
+  # shellcheck disable=SC1091
+  source "${ROOT_DIR}/.env"
+  set +a
+fi
+
+HAD_ENABLE_E2E_DEBUG=0
+ORIGINAL_ENABLE_E2E_DEBUG=""
+if [[ -n "${ENABLE_E2E_DEBUG+x}" ]]; then
+  HAD_ENABLE_E2E_DEBUG=1
+  ORIGINAL_ENABLE_E2E_DEBUG="$ENABLE_E2E_DEBUG"
+fi
+
+restore_enable_e2e_debug() {
+  if [[ "$HAD_ENABLE_E2E_DEBUG" -eq 1 ]]; then
+    export ENABLE_E2E_DEBUG="$ORIGINAL_ENABLE_E2E_DEBUG"
+  else
+    unset ENABLE_E2E_DEBUG
+  fi
+}
+trap restore_enable_e2e_debug EXIT
+
+export ENABLE_E2E_DEBUG=true
+
+if ! command -v uv >/dev/null 2>&1; then
+  echo "FAIL: uv is not installed or not on PATH" >&2
+  exit 1
+fi
+
+uv venv --allow-existing "$VENV_DIR"
+uv pip install --python "$PYTHON_BIN" -r requirements-api.txt pytest pytest-asyncio
+
+echo
+echo "================================================================================"
+echo "Running local e2e harness with structured tool debug verdicts"
+echo "ENABLE_E2E_DEBUG is enabled for this local harness process only."
+echo "================================================================================"
+echo
+
+"$PYTHON_BIN" scripts/e2e_cases.py --debug-tools --out-dir "$OUT_DIR" "$@"

--- a/tests/scripts/run_e2e_remote.sh
+++ b/tests/scripts/run_e2e_remote.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+VENV_DIR="${ROOT_DIR}/.venv-testplan"
+PYTHON_BIN="${VENV_DIR}/bin/python"
+OUT_DIR="${E2E_OUT_DIR:-e2e_runs/remote}"
+
+cd "$ROOT_DIR"
+
+if [[ "${E2E_LOAD_ENV:-1}" != "0" && -f "${ROOT_DIR}/.env" ]]; then
+  set -a
+  # shellcheck disable=SC1091
+  source "${ROOT_DIR}/.env"
+  set +a
+fi
+
+if [[ -z "${BASE_URL:-}" ]]; then
+  echo "FAIL: set BASE_URL to the deployed service URL before running remote e2e tests" >&2
+  exit 1
+fi
+
+if ! command -v uv >/dev/null 2>&1; then
+  echo "FAIL: uv is not installed or not on PATH" >&2
+  exit 1
+fi
+
+uv venv --allow-existing "$VENV_DIR"
+uv pip install --python "$PYTHON_BIN" -r requirements-api.txt pytest pytest-asyncio
+
+echo
+echo "================================================================================"
+echo "Running remote e2e harness against ${BASE_URL}"
+echo "Remote structured verdicts require ENABLE_E2E_DEBUG=true on the service."
+echo "Remote media cases require expected.json media_id values."
+echo "================================================================================"
+echo
+
+CMD=("$PYTHON_BIN" scripts/e2e_cases.py --base-url "$BASE_URL" --debug-tools --out-dir "$OUT_DIR")
+if [[ -n "${WEBHOOK_SECRET:-}" ]]; then
+  CMD+=(--secret "$WEBHOOK_SECRET")
+fi
+CMD+=("$@")
+
+"${CMD[@]}"

--- a/tests/scripts/run_e2e_suite.sh
+++ b/tests/scripts/run_e2e_suite.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+LOCAL_OUT_DIR="${E2E_OUT_DIR:-e2e_runs/local}"
+
+cd "$ROOT_DIR"
+
+if [[ "${E2E_LOAD_ENV:-1}" != "0" && -f "${ROOT_DIR}/.env" ]]; then
+  set -a
+  # shellcheck disable=SC1091
+  source "${ROOT_DIR}/.env"
+  set +a
+fi
+
+tests/scripts/run_e2e_local.sh "$@"
+
+RESULTS_JSON="$(find "$LOCAL_OUT_DIR" -mindepth 2 -maxdepth 2 -name results.json -print | sort | tail -n 1)"
+if [[ -z "$RESULTS_JSON" ]]; then
+  echo "FAIL: no e2e results.json found under ${LOCAL_OUT_DIR}" >&2
+  exit 1
+fi
+
+GATE_CMD=(
+  python tests/scripts/check_e2e_report.py "$RESULTS_JSON"
+  --max-unknown "${E2E_MAX_UNKNOWN:-0}"
+  --max-fp "${E2E_MAX_FP:-0}"
+)
+if [[ -n "${E2E_MAX_FN:-}" ]]; then
+  GATE_CMD+=(--max-fn "$E2E_MAX_FN")
+fi
+if [[ -n "${E2E_MIN_ACCURACY:-}" ]]; then
+  GATE_CMD+=(--min-accuracy "$E2E_MIN_ACCURACY")
+fi
+
+"${GATE_CMD[@]}"
+
+SUMMARY_MD="$(dirname "$RESULTS_JSON")/summary.md"
+echo
+echo "E2E summary: ${SUMMARY_MD}"


### PR DESCRIPTION
## Summary

Adds automation around the existing filesystem-driven e2e harness.

This PR adds local, remote, and suite scripts for running the e2e harness, report gating for CI-style pass/fail checks, README usage documentation, and per-case progress output in the e2e runner.

## Changes

  - Add `tests/scripts/run_e2e_local.sh`
  - Add `tests/scripts/run_e2e_remote.sh`
  - Add `tests/scripts/run_e2e_suite.sh`
  - Add `tests/scripts/check_e2e_report.py`
  - Add structured report gates for failed cases, unknown classifications, false positives, missing structured tool verdicts, optional false negatives, and minimum accuracy
  - Add real/fake grouped report summaries
  - Add local `.env` auto-loading and temporary `ENABLE_E2E_DEBUG=true`
  - Add per-case progress and colorized PASS/FAIL output to `scripts/e2e_cases.py`
  - Document e2e automation usage in `README.md`
  - Add an example fake e2e fixture

## Notes
The automation scripts wrap the existing e2e harness. They do not replace the harness behavior. Local runs can use local certificate fixtures, while remote runs require deployed-service access and remote media IDs.