### PR TITLE
feat: upload GiveLight handoffs to Google Drive

### DIFF
--- a/docs/integrations/google-drive-handoff.md
+++ b/docs/integrations/google-drive-handoff.md
@@ -1,0 +1,39 @@
+# Google Drive handoff
+
+Accepted death-certificate cases are uploaded to GiveLight as two files with a
+shared filename stem: the JSON verification payload and the original image (or
+PDF). The destination should be a folder in a Google Shared Drive.
+
+## Google Cloud and GiveLight setup
+
+1. Enable the Google Drive API in the Google Cloud project that runs the B2
+   WhatsApp adapter.
+2. Use the Cloud Run runtime service account through Application Default
+   Credentials (ADC). Do not create or send a service-account JSON key.
+3. Ask GiveLight to share the destination Shared Drive folder with the runtime
+   service-account email and grant it permission to add files.
+4. Copy the folder ID from its Drive URL and set it on the service as
+   `GOOGLE_DRIVE_FOLDER_ID`.
+5. Deploy a revision and verify that one accepted case creates both the JSON
+   payload and original document in the destination folder.
+
+The uploader requests only the
+`https://www.googleapis.com/auth/drive.file` OAuth scope. Store configuration in
+the deployment platform; never commit credentials or secret values.
+
+## WhatsApp configuration
+
+The current repository requires:
+
+- `WHATSAPP_TOKEN`: a production system-user access token with
+  `whatsapp_business_messaging`, used to retrieve incoming media.
+- `WHATSAPP_GRAPH_VERSION`: an optional, non-secret Graph API version override.
+- `WEBHOOK_SECRET`: the internal shared secret between the central B2 webhook
+  and this service.
+
+If this service later integrates directly with Meta, it will additionally need
+the Meta App ID and App Secret, WhatsApp Business Account (WABA) ID, Phone
+Number ID, and a separately generated webhook verification token. Grant
+`whatsapp_business_management` when account or template administration is
+needed. Share secret values only through the approved secret-management
+channel; do not send them in chat or commit them to the repository.

--- a/requirements-api.txt
+++ b/requirements-api.txt
@@ -13,3 +13,4 @@ numpy>=1.26.0
 pyyaml>=6.0
 python-dotenv>=1.0
 httpx>=0.27.0
+google-auth>=2.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,3 +33,4 @@ onnxruntime>=1.18.0
 python-multipart>=0.0.9
 pytest-asyncio>=0.23.0
 google-cloud-storage>=2.0.0
+google-auth>=2.0.0

--- a/tests/unit/test_verify_flow_integration.py
+++ b/tests/unit/test_verify_flow_integration.py
@@ -44,8 +44,10 @@ def test_model_call_pulls_image_and_hands_off(monkeypatch):
             justification="ok", extracted_fields={"full_name": "Jane Doe"},
         )
 
-    async def fake_deliver(payload):
+    async def fake_deliver(payload, image_bytes, mime_type):
         seen["handoff"] = payload
+        seen["handoff_image"] = image_bytes
+        seen["handoff_mime"] = mime_type
         return True
 
     monkeypatch.setattr(verify_module, "run_pipeline", fake_pipeline)
@@ -77,6 +79,8 @@ def test_model_call_pulls_image_and_hands_off(monkeypatch):
     # and the passing result was forwarded to GiveLight
     assert seen["handoff"]["score"] == 82
     assert len(seen["handoff"]["contact_identifier"]) == 64
+    assert seen["handoff_image"] == b"\xff\xd8jpeg-image-bytes"
+    assert seen["handoff_mime"] == "image/jpeg"
 
 
 def test_orphan_claim_document_upload_returns_tool_validation_output(monkeypatch):
@@ -103,8 +107,10 @@ def test_orphan_claim_document_upload_returns_tool_validation_output(monkeypatch
             },
         )
 
-    async def fake_deliver(payload):
+    async def fake_deliver(payload, image_bytes, mime_type):
         seen["handoff"] = payload
+        seen["handoff_image"] = image_bytes
+        seen["handoff_mime"] = mime_type
         return True
 
     monkeypatch.setattr(verify_module, "run_pipeline", fake_pipeline)
@@ -145,6 +151,8 @@ def test_orphan_claim_document_upload_returns_tool_validation_output(monkeypatch
     assert handoff["extracted_fields"]["full_name"] == "Jane Doe"
     assert handoff["case_fields"]["channel"] == "whatsapp"
     assert len(handoff["contact_identifier"]) == 64
+    assert seen["handoff_image"] == b"\xff\xd8jpeg-death-certificate"
+    assert seen["handoff_mime"] == "image/jpeg"
 
     tool_output = json.loads(response_text)["death_certificate_verification"]
     assert tool_output["status"] == "verified"

--- a/tests/unit/tools/death_certificate_pipeline/test_handoff.py
+++ b/tests/unit/tools/death_certificate_pipeline/test_handoff.py
@@ -1,0 +1,67 @@
+"""Tests for the Google Drive GiveLight handoff."""
+
+import json
+
+from tools.death_certificate_pipeline import handoff
+
+
+async def test_missing_folder_configuration_returns_false(monkeypatch):
+    monkeypatch.delenv("GOOGLE_DRIVE_FOLDER_ID", raising=False)
+
+    assert await handoff.deliver_to_gl({}, b"image", "image/jpeg") is False
+
+
+async def test_uploads_json_and_original_image(monkeypatch):
+    monkeypatch.setenv("GOOGLE_DRIVE_FOLDER_ID", "give-light-folder")
+
+    monkeypatch.setattr(handoff, "_get_access_token", lambda: "drive-token")
+
+    requests = []
+
+    class Response:
+        def raise_for_status(self):
+            return None
+
+    class Client:
+        def __init__(self, timeout):
+            assert timeout == 30.0
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            return None
+
+        async def post(self, url, **kwargs):
+            requests.append((url, kwargs))
+            return Response()
+
+    monkeypatch.setattr(handoff.httpx, "AsyncClient", Client)
+    payload = {
+        "submitted_at": "2026-08-07T12:34:56+00:00",
+        "contact_identifier": "a" * 64,
+        "score": 92,
+    }
+
+    assert await handoff.deliver_to_gl(payload, b"jpeg-bytes", "image/jpeg") is True
+    assert len(requests) == 2
+
+    metadata = []
+    contents = []
+    for url, kwargs in requests:
+        assert url == handoff._DRIVE_UPLOAD_URL
+        assert kwargs["params"] == {"uploadType": "multipart", "supportsAllDrives": "true"}
+        assert kwargs["headers"]["Authorization"] == "Bearer drive-token"
+        assert kwargs["headers"]["Content-Type"].startswith("multipart/related; boundary=")
+        _, remainder = kwargs["content"].split(b"\r\n\r\n", 1)
+        raw_metadata, remainder = remainder.split(b"\r\n--b2-drive-handoff\r\n", 1)
+        metadata.append(json.loads(raw_metadata))
+        contents.append(remainder.split(b"\r\n\r\n", 1)[1].rsplit(b"\r\n--", 1)[0])
+
+    json_name, image_name = metadata[0]["name"], metadata[1]["name"]
+    assert json_name.removesuffix(".json") == image_name.removesuffix(".jpg")
+    assert metadata[0]["parents"] == metadata[1]["parents"] == ["give-light-folder"]
+    assert metadata[0]["mimeType"] == "application/json"
+    assert metadata[1]["mimeType"] == "image/jpeg"
+    assert json.loads(contents[0]) == payload
+    assert contents[1] == b"jpeg-bytes"

--- a/tests/unit/tools/death_certificate_pipeline/test_verify.py
+++ b/tests/unit/tools/death_certificate_pipeline/test_verify.py
@@ -45,8 +45,10 @@ async def test_verify_accepts_and_hands_off(monkeypatch):
         seen["narrative"] = submission.narrative
         return _result(Band.HIGH)
 
-    async def fake_deliver(payload):
+    async def fake_deliver(payload, image_bytes, mime_type):
         seen["payload"] = payload
+        seen["handoff_image"] = image_bytes
+        seen["handoff_mime"] = mime_type
         return True
 
     monkeypatch.setattr(verify_module, "run_pipeline", fake_pipeline)
@@ -62,6 +64,8 @@ async def test_verify_accepts_and_hands_off(monkeypatch):
     # handoff payload carries a non-reversible contact id and the score
     assert seen["payload"]["score"] == 80
     assert seen["payload"]["contact_identifier"] and len(seen["payload"]["contact_identifier"]) == 64
+    assert seen["handoff_image"] == b"\xff\xd8jpeg"
+    assert seen["handoff_mime"] == "image/jpeg"
 
 
 async def test_verify_holds_back_on_hard_escalation(monkeypatch):
@@ -70,7 +74,7 @@ async def test_verify_holds_back_on_hard_escalation(monkeypatch):
     async def fake_pipeline(submission):
         return _result(Band.ESCALATE, flags=["HARD_ESCALATION"])
 
-    async def fake_deliver(payload):
+    async def fake_deliver(payload, image_bytes, mime_type):
         delivered["called"] = True
         return True
 
@@ -100,7 +104,7 @@ async def test_verify_appends_debug_event(monkeypatch):
     async def fake_pipeline(submission):
         return _result(Band.MEDIUM)
 
-    async def fake_deliver(payload):
+    async def fake_deliver(payload, image_bytes, mime_type):
         return False
 
     monkeypatch.setattr(verify_module, "run_pipeline", fake_pipeline)

--- a/tools/death_certificate_pipeline/handoff.py
+++ b/tools/death_certificate_pipeline/handoff.py
@@ -1,23 +1,27 @@
-"""GL handoff — package the scored result for GiveLight delivery.
-
-Stub implementation. Wire real GL endpoint when GL-20 lands.
-
-The handoff bundle contains:
-  - contact_identifier  (HMAC-SHA256 join key — no raw PII)
-  - ReliabilityResult   (score, band, flags, extracted_fields)
-  - case_fields         (operator metadata from Submission)
-"""
+"""Package scored death-certificate results and upload them to GiveLight."""
 
 from __future__ import annotations
 
+import asyncio
 import json
-import logging
+import os
 from datetime import datetime, timezone
 from typing import Any
 
+import httpx
+
 from tools.death_certificate_pipeline.models import ReliabilityResult
 
-logger = logging.getLogger(__name__)
+_DRIVE_SCOPE = "https://www.googleapis.com/auth/drive.file"
+_DRIVE_UPLOAD_URL = "https://www.googleapis.com/upload/drive/v3/files"
+_IMAGE_EXTENSIONS = {
+    "image/jpeg": ".jpg",
+    "image/png": ".png",
+    "image/webp": ".webp",
+    "image/heic": ".heic",
+    "image/heif": ".heif",
+    "application/pdf": ".pdf",
+}
 
 
 def build_handoff_payload(
@@ -40,16 +44,94 @@ def build_handoff_payload(
     }
 
 
-async def deliver_to_gl(payload: dict[str, Any]) -> bool:
-    """Stub: log the handoff payload. Replace with real GL endpoint (GL-20).
+def _multipart_body(metadata: dict[str, Any], content: bytes, mime_type: str) -> tuple[str, bytes]:
+    boundary = "b2-drive-handoff"
+    body = (
+        f"--{boundary}\r\n"
+        "Content-Type: application/json; charset=UTF-8\r\n\r\n"
+    ).encode() + json.dumps(metadata).encode("utf-8") + (
+        f"\r\n--{boundary}\r\n"
+        f"Content-Type: {mime_type}\r\n\r\n"
+    ).encode() + content + f"\r\n--{boundary}--\r\n".encode()
+    return boundary, body
 
-    Returns True on confirmed delivery, False on failure.
-    """
-    logger.info(
-        "gl.handoff_stub score=%d band=%s contact=%.8s — GL-20 endpoint not yet wired",
-        payload.get("score"),
-        payload.get("band"),
-        str(payload.get("contact_identifier") or ""),
+
+def _get_access_token() -> str:
+    import google.auth
+    from google.auth.exceptions import GoogleAuthError
+    from google.auth.transport.requests import Request
+
+    try:
+        credentials, _ = google.auth.default(scopes=[_DRIVE_SCOPE])
+        credentials.refresh(Request())
+    except GoogleAuthError as exc:
+        raise ValueError("Google Drive authentication failed") from exc
+    if not credentials.token:
+        raise ValueError("Google Drive authentication returned no access token")
+    return credentials.token
+
+
+async def _upload_file(
+    client: httpx.AsyncClient,
+    token: str,
+    folder_id: str,
+    name: str,
+    content: bytes,
+    mime_type: str,
+) -> None:
+    boundary, body = _multipart_body(
+        {"name": name, "parents": [folder_id], "mimeType": mime_type},
+        content,
+        mime_type,
     )
-    logger.debug("gl.handoff_payload %s", json.dumps(payload, ensure_ascii=False))
-    return True
+    response = await client.post(
+        _DRIVE_UPLOAD_URL,
+        params={"uploadType": "multipart", "supportsAllDrives": "true"},
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Content-Type": f"multipart/related; boundary={boundary}",
+        },
+        content=body,
+    )
+    response.raise_for_status()
+
+
+async def deliver_to_gl(
+    payload: dict[str, Any], image_bytes: bytes, image_mime_type: str
+) -> bool:
+    """Upload a JSON payload and its source image to GiveLight's Drive folder."""
+    folder_id = os.getenv("GOOGLE_DRIVE_FOLDER_ID")
+    if not folder_id:
+        return False
+
+    try:
+        token = await asyncio.to_thread(_get_access_token)
+
+        contact = str(payload.get("contact_identifier") or "unlinked")[:16]
+        submitted_at = str(payload.get("submitted_at") or "").replace(":", "-")
+        stem = f"death-certificate-{contact}-{submitted_at}"
+        extension = _IMAGE_EXTENSIONS.get(image_mime_type, ".bin")
+        upload_mime_type = (
+            image_mime_type if image_mime_type in _IMAGE_EXTENSIONS else "application/octet-stream"
+        )
+
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            await _upload_file(
+                client,
+                token,
+                folder_id,
+                f"{stem}.json",
+                json.dumps(payload, ensure_ascii=False, indent=2).encode("utf-8"),
+                "application/json",
+            )
+            await _upload_file(
+                client,
+                token,
+                folder_id,
+                f"{stem}{extension}",
+                image_bytes,
+                upload_mime_type,
+            )
+        return True
+    except (httpx.HTTPError, OSError, ValueError):
+        return False

--- a/tools/death_certificate_pipeline/verify.py
+++ b/tools/death_certificate_pipeline/verify.py
@@ -76,7 +76,7 @@ async def verify_death_certificate(ctx: Any) -> dict[str, Any]:
         _append_debug_event(deps, payload, accepted=None)
         return payload
 
-    image_bytes, _mime = media
+    image_bytes, mime_type = media
     narrative = (getattr(deps, "history_text", "") or "").strip() or _NARRATIVE_FALLBACK
 
     submission = Submission(
@@ -95,7 +95,7 @@ async def verify_death_certificate(ctx: Any) -> dict[str, Any]:
             contact_identifier=_contact_identifier(session_id),
             case_fields=submission.case_fields,
         )
-        handed_off = await deliver_to_gl(payload)
+        handed_off = await deliver_to_gl(payload, image_bytes, mime_type)
 
     logger.info(
         "verify.done session=%.8s score=%d band=%s accepted=%s handed_off=%s",


### PR DESCRIPTION
## Summary

Replaces the GiveLight handoff stub with a Google Drive delivery flow.

Accepted death-certificate submissions now upload:

- The structured JSON verification payload
- The original image or PDF

Both files use a shared case-specific filename and are placed in the configured GiveLight Shared Drive folder.

## Implementation

- Uses Google Application Default Credentials and the Cloud Run service account
- Uses the limited `drive.file` OAuth scope
- Supports Shared Drive uploads
- Reads the destination from `GOOGLE_DRIVE_FOLDER_ID`
- Preserves the existing verification acceptance policy
- Returns an unsuccessful handoff result when configuration, authentication, or upload fails
- Documents Google Drive and WhatsApp credential requirements

## Validation

- Handoff and verification tests pass: `8 passed`
- Python compilation check passes
- Git diff validation passes
- Rebased onto current `b2/main`

## Outstanding validation

The implementation is complete but has **not yet been tested against GiveLight’s actual Google Drive**.
