### PR TITLE
Add e2e summary reporting and WhatsApp summary delivery

### DIFF
--- a/e2e/reports.py
+++ b/e2e/reports.py
@@ -54,17 +54,18 @@ def render_markdown(report: dict[str, Any]) -> str:
             "",
             "## Cases",
             "",
-            "| Case | Result | Expected | Actual | Class | Final Response Chars | Errors |",
-            "| --- | --- | --- | --- | --- | ---: | --- |",
+            "| Case | Result | Expected | Actual | Class | Final Response Chars | Summary Tool Response | Errors |",
+            "| --- | --- | --- | --- | --- | ---: | --- | --- |",
         ]
     )
     for result in report["results"]:
         status = "PASS" if result["passed"] else "FAIL"
-        errors = "<br>".join(result["errors"]) if result["errors"] else ""
+        errors = _markdown_cell("<br>".join(result["errors"]) if result["errors"] else "")
+        summary_tool_response = _markdown_cell(result.get("summary_tool_response"))
         lines.append(
             f"| `{result['case']}` | {status} | {result['expected_outcome']} | "
             f"{result['actual_outcome']} | {result['classification']} | "
-            f"{len(result['final_response'])} | {errors} |"
+            f"{len(result['final_response'])} | {summary_tool_response} | {errors} |"
         )
     lines.append("")
     return "\n".join(lines)
@@ -83,3 +84,6 @@ def _percent(value: float | None) -> str:
         return "n/a"
     return f"{value:.1%}"
 
+
+def _markdown_cell(value: Any) -> str:
+    return str(value or "").replace("|", "\\|").replace("\n", "<br>")

--- a/e2e/runner.py
+++ b/e2e/runner.py
@@ -9,6 +9,7 @@ from e2e.assertions import actual_outcome, assert_case, classification, expected
 from e2e.cases import Case
 from e2e.local_app import register_local_media
 from e2e.payloads import meta_media_payload, meta_text_payload, mime_for_path
+from e2e.summary_tool import summarize_case_result
 
 
 def run_all(
@@ -121,7 +122,7 @@ def run_case(
     classified_as = classification(expected_value, actual_value)
     passed = not errors and classified_as != "UNKNOWN"
 
-    return {
+    result = {
         "case": case.label,
         "country": case.country,
         "kind": case.kind,
@@ -140,6 +141,8 @@ def run_case(
         "errors": errors,
         "passed": passed,
     }
+    result["summary_tool_response"] = summarize_case_result(result)
+    return result
 
 
 def post_turn(

--- a/e2e/summary_tool.py
+++ b/e2e/summary_tool.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any
+
+from pydantic_ai import Agent
+from pydantic_ai.messages import (
+    ModelMessage,
+    ModelMessagesTypeAdapter,
+    ModelRequest,
+    ModelResponse,
+    TextPart,
+    UserPromptPart,
+)
+
+from tools.summary.summary import ConversationSummaryTool
+
+SUMMARY_TOOL_ERROR_PREFIX = "summary_tool_error: "
+
+
+def summarize_case_result(result: dict[str, Any]) -> str:
+    messages = build_summary_messages(result)
+    try:
+        return run_summary_tool(messages)
+    except Exception as exc:
+        return f"{SUMMARY_TOOL_ERROR_PREFIX}{type(exc).__name__}: {exc}"
+
+
+def build_summary_messages(result: dict[str, Any]) -> list[ModelMessage]:
+    return [
+        ModelRequest(parts=[UserPromptPart(content=summary_prompt(result))]),
+        ModelResponse(parts=[TextPart(content=str(result.get("final_response") or ""))]),
+    ]
+
+
+def run_summary_tool(messages: list[ModelMessage]) -> str:
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return asyncio.run(call_summary_tool(messages))
+    raise RuntimeError("summary tool cannot be run from an active event loop")
+
+
+async def call_summary_tool(messages: list[ModelMessage]) -> str:
+    tool = ConversationSummaryTool(
+        agent=Agent("google-vertex:gemini-2.5-flash"),
+        scrubber=E2ESummaryScrubber(),
+        audit_store=E2ESummaryAuditStore(),
+    )
+    return await tool.run(summary_tool_messages(messages))
+
+
+def summary_prompt(result: dict[str, Any]) -> str:
+    return (
+        "Summarize this e2e test case result for the operator. Include the case identity, "
+        "expected outcome, actual outcome, classification, pass/fail status, assertion errors, "
+        "death-certificate tool result, skipped turns, and a concise explanation of what happened. "
+        "Preserve any existing summary fields as source data; do not replace them.\n\n"
+        f"{json.dumps(summary_payload(result), indent=2, ensure_ascii=False, default=str)}"
+    )
+
+
+def summary_payload(result: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "case": result.get("case"),
+        "country": result.get("country"),
+        "kind": result.get("kind"),
+        "case_id": result.get("case_id"),
+        "expected_outcome": result.get("expected_outcome"),
+        "actual_outcome": result.get("actual_outcome"),
+        "classification": result.get("classification"),
+        "verdict_source": result.get("verdict_source"),
+        "passed": result.get("passed"),
+        "errors": result.get("errors", []),
+        "skipped_turns": result.get("skipped_turns", []),
+        "tool_result": result.get("tool_result"),
+        "turns": [compact_turn(turn) for turn in result.get("turns", [])],
+    }
+
+
+def compact_turn(turn: dict[str, Any]) -> dict[str, Any]:
+    response_json = turn.get("response_json")
+    response_body = None
+    if isinstance(response_json, dict):
+        response_body = response_json.get("response")
+    return {
+        "label": turn.get("label"),
+        "status_code": turn.get("status_code"),
+        "latency_seconds": turn.get("latency_seconds"),
+        "response": response_body if response_body is not None else turn.get("response_text"),
+    }
+
+
+def summary_tool_messages(messages: list[ModelMessage]) -> list[SummaryToolMessage]:
+    return [SummaryToolMessage(message) for message in messages]
+
+
+class SummaryToolMessage:
+    def __init__(self, message: ModelMessage) -> None:
+        self.message = message
+
+    def model_dump_json(self, *, exclude_none: bool = False, **kwargs: Any) -> str:
+        dumped = ModelMessagesTypeAdapter.dump_python([self.message], exclude_none=exclude_none)[0]
+        return json.dumps(dumped, ensure_ascii=False, default=str)
+
+
+class E2ESummaryScrubber:
+    def scrub(self, transcript: str, *, audit_store: Any) -> str:
+        return transcript
+
+
+class E2ESummaryAuditStore:
+    pass

--- a/src/api.py
+++ b/src/api.py
@@ -15,6 +15,8 @@ from fastapi import FastAPI, Header, HTTPException, Request
 from starlette.concurrency import run_in_threadpool
 
 from .chat import chat
+from .summary_response import generate_summary_tool_response
+from .whatsapp_outbound import can_send_text_message, send_text_message
 from .whatsapp_media import download_media
 
 logger = logging.getLogger(__name__)
@@ -40,6 +42,7 @@ class InboundMessage:
     text: str | None = None
     media_id: str | None = None
     mime_type: str | None = None
+    phone_number_id: str | None = None
 
 
 def _debug_response(
@@ -65,11 +68,13 @@ def _extract_message(payload: dict[str, Any]) -> InboundMessage:
     try:
         entry = (payload.get("entry") or [])[0]
         value = (entry.get("changes") or [])[0].get("value", {})
+        metadata = value.get("metadata") or {}
         contacts = value.get("contacts") or []
         messages = value.get("messages") or []
+        phone_number_id = metadata.get("phone_number_id")
 
         if not messages:
-            return InboundMessage()
+            return InboundMessage(phone_number_id=phone_number_id)
 
         msg = messages[0]
         msg_type = msg.get("type")
@@ -78,17 +83,22 @@ def _extract_message(payload: dict[str, Any]) -> InboundMessage:
         if msg_type == "text":
             text = (msg.get("text") or {}).get("body", "").strip()
             if not text:
-                return InboundMessage(wa_id=wa_id)
-            return InboundMessage(wa_id=wa_id, text=text)
+                return InboundMessage(wa_id=wa_id, phone_number_id=phone_number_id)
+            return InboundMessage(wa_id=wa_id, text=text, phone_number_id=phone_number_id)
 
         if msg_type in _MEDIA_TYPES:
             media = msg.get(msg_type) or {}
             media_id = media.get("id")
             if not media_id:
-                return InboundMessage(wa_id=wa_id)
-            return InboundMessage(wa_id=wa_id, media_id=media_id, mime_type=media.get("mime_type"))
+                return InboundMessage(wa_id=wa_id, phone_number_id=phone_number_id)
+            return InboundMessage(
+                wa_id=wa_id,
+                media_id=media_id,
+                mime_type=media.get("mime_type"),
+                phone_number_id=phone_number_id,
+            )
 
-        return InboundMessage(wa_id=wa_id)
+        return InboundMessage(wa_id=wa_id, phone_number_id=phone_number_id)
     except (IndexError, AttributeError, TypeError, KeyError):
         return InboundMessage()
 
@@ -107,7 +117,7 @@ async def message_endpoint(
 
     message = _extract_message(payload)
     debug_enabled = _truthy(_ENABLE_E2E_DEBUG) and _truthy(x_e2e_debug)
-    debug_events: list[dict[str, Any]] | None = [] if debug_enabled else None
+    debug_events: list[dict[str, Any]] = []
 
     if message.text is not None:
         logger.info("api.message routing text wa_id=%s chars=%d", message.wa_id, len(message.text))
@@ -118,6 +128,7 @@ async def message_endpoint(
             debug_events=debug_events,
         )
         logger.info("api.message done wa_id=%s response_chars=%d", message.wa_id, len(response))
+        await _send_summary_tool_response(message, response, debug_events)
         if debug_enabled:
             return _debug_response(response, message, debug_events or [])
         return {"response": response}
@@ -139,6 +150,7 @@ async def message_endpoint(
             debug_events=debug_events,
         )
         logger.info("api.message done wa_id=%s response_chars=%d", message.wa_id, len(response))
+        await _send_summary_tool_response(message, response, debug_events)
         if debug_enabled:
             return _debug_response(response, message, debug_events or [])
         return {"response": response}
@@ -152,3 +164,25 @@ async def message_endpoint(
 @app.get("/health")
 def health() -> dict[str, str]:
     return {"status": "ok"}
+
+
+async def _send_summary_tool_response(
+    message: InboundMessage,
+    response: str,
+    debug_events: list[dict[str, Any]],
+) -> None:
+    if not can_send_text_message(wa_id=message.wa_id, phone_number_id=message.phone_number_id):
+        return
+
+    summary = await generate_summary_tool_response(
+        final_response=response,
+        tool_events=debug_events,
+    )
+    if not summary:
+        return
+
+    await send_text_message(
+        wa_id=message.wa_id,
+        text=summary,
+        phone_number_id=message.phone_number_id,
+    )

--- a/src/summary_response.py
+++ b/src/summary_response.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+from pydantic_ai import Agent
+from pydantic_ai.messages import (
+    ModelMessage,
+    ModelMessagesTypeAdapter,
+    ModelRequest,
+    ModelResponse,
+    TextPart,
+    UserPromptPart,
+)
+
+from tools.summary.summary import ConversationSummaryTool
+
+logger = logging.getLogger(__name__)
+
+SUMMARY_MODEL = "google-vertex:gemini-2.5-flash"
+
+
+async def generate_summary_tool_response(
+    *,
+    final_response: str,
+    tool_events: list[dict[str, Any]] | None = None,
+) -> str | None:
+    try:
+        messages = build_summary_messages(final_response=final_response, tool_events=tool_events or [])
+        return await call_summary_tool(messages)
+    except Exception as exc:
+        logger.warning("summary_response.generate skipped error=%s", exc)
+        return None
+
+
+def build_summary_messages(
+    *,
+    final_response: str,
+    tool_events: list[dict[str, Any]],
+) -> list[ModelMessage]:
+    return [
+        ModelRequest(parts=[UserPromptPart(content=summary_prompt(final_response, tool_events))]),
+        ModelResponse(parts=[TextPart(content=final_response)]),
+    ]
+
+
+def summary_prompt(final_response: str, tool_events: list[dict[str, Any]]) -> str:
+    return (
+        "Write a concise WhatsApp-ready message for the user based on this result. "
+        "Do not mention internal tools, debug output, e2e tests, JSON, prompts, or implementation details. "
+        "Use plain, compassionate language. Maximum two sentences.\n\n"
+        f"{json.dumps(summary_payload(final_response, tool_events), indent=2, ensure_ascii=False, default=str)}"
+    )
+
+
+def summary_payload(final_response: str, tool_events: list[dict[str, Any]]) -> dict[str, Any]:
+    verification = death_certificate_verification(tool_events)
+    payload: dict[str, Any] = {"assistant_response": final_response}
+    if verification is not None:
+        payload["death_certificate_verification"] = verification
+    return payload
+
+
+def death_certificate_verification(tool_events: list[dict[str, Any]]) -> dict[str, Any] | None:
+    for event in reversed(tool_events):
+        if event.get("tool") != "death_certificate_verification":
+            continue
+        return {
+            "status": event.get("status"),
+            "accepted": event.get("accepted"),
+            "handed_off": event.get("handed_off"),
+            "summary": event.get("summary"),
+            "flags": list(event.get("flags", [])),
+        }
+    return None
+
+
+async def call_summary_tool(messages: list[ModelMessage]) -> str:
+    tool = ConversationSummaryTool(
+        agent=Agent(SUMMARY_MODEL),
+        scrubber=SummaryResponseScrubber(),
+        audit_store=SummaryResponseAuditStore(),
+    )
+    return await tool.run(summary_tool_messages(messages))
+
+
+def summary_tool_messages(messages: list[ModelMessage]) -> list[SummaryToolMessage]:
+    return [SummaryToolMessage(message) for message in messages]
+
+
+class SummaryToolMessage:
+    def __init__(self, message: ModelMessage) -> None:
+        self.message = message
+
+    def model_dump_json(self, *, exclude_none: bool = False, **kwargs: Any) -> str:
+        dumped = ModelMessagesTypeAdapter.dump_python([self.message], exclude_none=exclude_none)[0]
+        return json.dumps(dumped, ensure_ascii=False, default=str)
+
+
+class SummaryResponseScrubber:
+    def scrub(self, transcript: str, *, audit_store: Any) -> str:
+        return transcript
+
+
+class SummaryResponseAuditStore:
+    pass

--- a/src/whatsapp_outbound.py
+++ b/src/whatsapp_outbound.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import logging
+import os
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+_GRAPH_BASE = "https://graph.facebook.com"
+_DEFAULT_GRAPH_VERSION = "v21.0"
+_TIMEOUT = 30.0
+
+
+def outbound_disabled() -> bool:
+    return _truthy(os.getenv("E2E_DISABLE_WHATSAPP_OUTBOUND"))
+
+
+def can_send_text_message(*, wa_id: str | None, phone_number_id: str | None = None) -> bool:
+    if outbound_disabled():
+        logger.info("whatsapp_outbound.send skipped disabled=true")
+        return False
+    if not os.getenv("WHATSAPP_TOKEN", ""):
+        logger.warning("whatsapp_outbound.send skipped missing WHATSAPP_TOKEN")
+        return False
+    if not (phone_number_id or os.getenv("WHATSAPP_PHONE_NUMBER_ID", "")):
+        logger.warning("whatsapp_outbound.send skipped missing phone_number_id")
+        return False
+    if not wa_id:
+        logger.warning("whatsapp_outbound.send skipped missing recipient")
+        return False
+    return True
+
+
+async def send_text_message(
+    *,
+    wa_id: str | None,
+    text: str | None,
+    phone_number_id: str | None = None,
+) -> bool:
+    body = (text or "").strip()
+
+    if not can_send_text_message(wa_id=wa_id, phone_number_id=phone_number_id):
+        return False
+    if not body:
+        logger.warning("whatsapp_outbound.send skipped empty text")
+        return False
+
+    token = os.getenv("WHATSAPP_TOKEN", "")
+    sender_id = phone_number_id or os.getenv("WHATSAPP_PHONE_NUMBER_ID", "")
+    version = os.getenv("WHATSAPP_GRAPH_VERSION", _DEFAULT_GRAPH_VERSION)
+    url = f"{_GRAPH_BASE}/{version}/{sender_id}/messages"
+    headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
+    payload = {
+        "messaging_product": "whatsapp",
+        "to": wa_id,
+        "type": "text",
+        "text": {"body": body},
+    }
+
+    try:
+        async with httpx.AsyncClient(timeout=_TIMEOUT) as client:
+            response = await client.post(url, json=payload, headers=headers)
+            response.raise_for_status()
+    except httpx.HTTPError as exc:
+        logger.error("whatsapp_outbound.send failed recipient=%.8s error=%s", wa_id, exc)
+        return False
+
+    logger.info("whatsapp_outbound.send ok recipient=%.8s chars=%d", wa_id, len(body))
+    return True
+
+
+def _truthy(value: str | None) -> bool:
+    return str(value or "").strip().lower() in {"1", "true", "yes", "on"}

--- a/tests/scripts/run_e2e_local.sh
+++ b/tests/scripts/run_e2e_local.sh
@@ -32,6 +32,7 @@ restore_enable_e2e_debug() {
 trap restore_enable_e2e_debug EXIT
 
 export ENABLE_E2E_DEBUG=true
+export E2E_DISABLE_WHATSAPP_OUTBOUND=true
 
 if ! command -v uv >/dev/null 2>&1; then
   echo "FAIL: uv is not installed or not on PATH" >&2

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -117,6 +117,10 @@ async def _run_direct(func, **kwargs):
     return func(**kwargs)
 
 
+async def _no_summary(**kwargs):
+    return None
+
+
 # ---------------------------------------------------------------------------
 # _extract_message unit tests
 # ---------------------------------------------------------------------------
@@ -127,6 +131,7 @@ def test_extract_message_text():
     assert msg.wa_id == "16508106640"
     assert msg.text == "Hello B2, what is Givelight?"
     assert msg.media_id is None
+    assert msg.phone_number_id == "1104821716055506"
 
 
 def test_extract_message_status_update_returns_empty():
@@ -143,6 +148,7 @@ def test_extract_message_image_returns_media_id():
     assert msg.text is None
     assert msg.media_id == "media-123"
     assert msg.mime_type == "image/jpeg"
+    assert msg.phone_number_id is None
 
 
 def test_extract_message_empty_payload():
@@ -225,6 +231,7 @@ async def test_message_image_downloads_and_calls_chat(monkeypatch):
     monkeypatch.setattr(api_module, "download_media", fake_download)
     monkeypatch.setattr(api_module, "chat", fake_chat)
     monkeypatch.setattr(api_module, "run_in_threadpool", _run_direct)
+    monkeypatch.setattr(api_module, "generate_summary_tool_response", _no_summary)
 
     response = await api_module.message_endpoint(FakeRequest(IMAGE_PAYLOAD))
     assert response == {"response": "Your request is being processed."}
@@ -247,6 +254,7 @@ async def test_message_text_calls_chat(monkeypatch):
 
     monkeypatch.setattr(api_module, "chat", fake_chat)
     monkeypatch.setattr(api_module, "run_in_threadpool", _run_direct)
+    monkeypatch.setattr(api_module, "generate_summary_tool_response", _no_summary)
 
     response = await api_module.message_endpoint(FakeRequest(SAMPLE_TEXT_PAYLOAD))
     assert response == {"response": "Givelight is an orphan aid programme."}
@@ -254,7 +262,7 @@ async def test_message_text_calls_chat(monkeypatch):
     assert captured["session_id"] == "16508106640"
 
 
-def test_message_text_debug_requires_env_and_header(monkeypatch):
+async def test_message_text_debug_requires_env_and_header(monkeypatch):
     import src.api as api_module
     monkeypatch.setattr(api_module, "_WEBHOOK_SECRET", "")
     monkeypatch.setattr(api_module, "_ENABLE_E2E_DEBUG", "true")
@@ -266,15 +274,118 @@ def test_message_text_debug_requires_env_and_header(monkeypatch):
         return "ok"
 
     monkeypatch.setattr(api_module, "chat", fake_chat)
+    monkeypatch.setattr(api_module, "run_in_threadpool", _run_direct)
+    monkeypatch.setattr(api_module, "generate_summary_tool_response", _no_summary)
 
-    client = TestClient(api_module.app)
-    r = client.post("/message", json=SAMPLE_TEXT_PAYLOAD)
-    assert r.status_code == 200
-    assert r.json() == {"response": "ok"}
-    assert captured["debug_events"] is None
+    response = await api_module.message_endpoint(FakeRequest(SAMPLE_TEXT_PAYLOAD))
+    assert response == {"response": "ok"}
+    assert captured["debug_events"] == []
 
 
-def test_message_text_debug_returns_tool_results(monkeypatch):
+async def test_message_text_sends_summary_tool_response_as_second_message(monkeypatch):
+    import src.api as api_module
+    monkeypatch.setattr(api_module, "_WEBHOOK_SECRET", "")
+
+    captured = {}
+
+    def fake_chat(*, text, session_id, debug_events=None, **kwargs):
+        debug_events.append(
+            {
+                "tool": "death_certificate_verification",
+                "accepted": True,
+                "handed_off": True,
+                "summary": "Verification passed.",
+                "flags": [],
+            }
+        )
+        return "The request was accepted."
+
+    async def fake_generate_summary(*, final_response, tool_events):
+        captured["summary_input"] = {
+            "final_response": final_response,
+            "tool_events": list(tool_events),
+        }
+        return "Your certificate was verified and forwarded to GiveLight."
+
+    async def fake_send_text_message(*, wa_id, text, phone_number_id=None):
+        captured["send"] = {
+            "wa_id": wa_id,
+            "text": text,
+            "phone_number_id": phone_number_id,
+        }
+        return True
+
+    monkeypatch.setattr(api_module, "chat", fake_chat)
+    monkeypatch.setattr(api_module, "run_in_threadpool", _run_direct)
+    monkeypatch.setattr(api_module, "can_send_text_message", lambda *, wa_id, phone_number_id=None: True)
+    monkeypatch.setattr(api_module, "generate_summary_tool_response", fake_generate_summary)
+    monkeypatch.setattr(api_module, "send_text_message", fake_send_text_message)
+
+    response = await api_module.message_endpoint(FakeRequest(SAMPLE_TEXT_PAYLOAD))
+
+    assert response == {"response": "The request was accepted."}
+    assert captured["summary_input"]["final_response"] == "The request was accepted."
+    assert captured["summary_input"]["tool_events"][0]["summary"] == "Verification passed."
+    assert captured["send"] == {
+        "wa_id": "16508106640",
+        "text": "Your certificate was verified and forwarded to GiveLight.",
+        "phone_number_id": "1104821716055506",
+    }
+
+
+async def test_message_text_skips_summary_when_outbound_is_not_configured(monkeypatch):
+    import src.api as api_module
+    monkeypatch.setattr(api_module, "_WEBHOOK_SECRET", "")
+
+    called = {"summary": False}
+
+    def fake_chat(*, text, session_id, debug_events=None, **kwargs):
+        return "ok"
+
+    async def fake_generate_summary(*, final_response, tool_events):
+        called["summary"] = True
+        return "summary"
+
+    monkeypatch.setattr(api_module, "chat", fake_chat)
+    monkeypatch.setattr(api_module, "run_in_threadpool", _run_direct)
+    monkeypatch.setattr(api_module, "can_send_text_message", lambda *, wa_id, phone_number_id=None: False)
+    monkeypatch.setattr(api_module, "generate_summary_tool_response", fake_generate_summary)
+
+    response = await api_module.message_endpoint(FakeRequest(SAMPLE_TEXT_PAYLOAD))
+
+    assert response == {"response": "ok"}
+    assert called["summary"] is False
+
+
+async def test_message_text_keeps_original_response_when_summary_generation_fails(monkeypatch):
+    import src.api as api_module
+    monkeypatch.setattr(api_module, "_WEBHOOK_SECRET", "")
+
+    sent = {"called": False}
+
+    def fake_chat(*, text, session_id, debug_events=None, **kwargs):
+        return "ok"
+
+    async def fake_generate_summary(*, final_response, tool_events):
+        return None
+
+    async def fake_send_text_message(*, wa_id, text, phone_number_id=None):
+        sent["called"] = True
+        return True
+
+    monkeypatch.setattr(api_module, "chat", fake_chat)
+    monkeypatch.setattr(api_module, "run_in_threadpool", _run_direct)
+    monkeypatch.setattr(api_module, "can_send_text_message", lambda *, wa_id, phone_number_id=None: True)
+    monkeypatch.setattr(api_module, "generate_summary_tool_response", fake_generate_summary)
+    monkeypatch.setattr(api_module, "send_text_message", fake_send_text_message)
+
+    response = await api_module.message_endpoint(FakeRequest(SAMPLE_TEXT_PAYLOAD))
+
+    assert response == {"response": "ok"}
+    assert sent["called"] is False
+
+
+async def test_message_text_debug_returns_tool_results(monkeypatch):
     import src.api as api_module
     monkeypatch.setattr(api_module, "_WEBHOOK_SECRET", "")
     monkeypatch.setattr(api_module, "_ENABLE_E2E_DEBUG", "yes")
@@ -297,11 +408,11 @@ def test_message_text_debug_returns_tool_results(monkeypatch):
         return "ok"
 
     monkeypatch.setattr(api_module, "chat", fake_chat)
+    monkeypatch.setattr(api_module, "run_in_threadpool", _run_direct)
+    monkeypatch.setattr(api_module, "generate_summary_tool_response", _no_summary)
 
-    client = TestClient(api_module.app)
-    r = client.post("/message", json=SAMPLE_TEXT_PAYLOAD, headers={"X-E2E-Debug": "true"})
-    assert r.status_code == 200
-    assert r.json() == {
+    response = await api_module.message_endpoint(FakeRequest(SAMPLE_TEXT_PAYLOAD), x_e2e_debug="true")
+    assert response == {
         "response": "ok",
         "debug": {
             "session_id": "16508106640",
@@ -358,6 +469,7 @@ async def test_message_correct_secret_passes(monkeypatch):
     monkeypatch.setattr(api_module, "_WEBHOOK_SECRET", "mysecret")
     monkeypatch.setattr(api_module, "chat", lambda *, text, **kw: "ok")
     monkeypatch.setattr(api_module, "run_in_threadpool", _run_direct)
+    monkeypatch.setattr(api_module, "generate_summary_tool_response", _no_summary)
 
     response = await api_module.message_endpoint(
         FakeRequest(SAMPLE_TEXT_PAYLOAD),

--- a/tests/unit/test_e2e_reports.py
+++ b/tests/unit/test_e2e_reports.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from e2e.reports import render_markdown
+
+
+def test_render_markdown_includes_summary_tool_response_column() -> None:
+    markdown = render_markdown(
+        {
+            "base_url": "http://testserver",
+            "total": 1,
+            "passed": 0,
+            "failed": 1,
+            "stats": {
+                "overall": {
+                    "total": 1,
+                    "classified": 1,
+                    "accuracy": 0.0,
+                    "false_positives": 0,
+                    "false_negatives": 1,
+                    "unknown": 0,
+                },
+                "by_country": {},
+            },
+            "results": [
+                {
+                    "case": "example/real/case_001",
+                    "passed": False,
+                    "expected_outcome": "accept",
+                    "actual_outcome": "reject",
+                    "classification": "FN",
+                    "final_response": "Rejected.",
+                    "summary_tool_response": "Line one\nLine | two",
+                    "errors": ["actual outcome 'reject' != expected 'accept'"],
+                }
+            ],
+        }
+    )
+
+    assert (
+        "| Case | Result | Expected | Actual | Class | Final Response Chars | "
+        "Summary Tool Response | Errors |"
+    ) in markdown
+    assert (
+        "| `example/real/case_001` | FAIL | accept | reject | FN | 9 | "
+        "Line one<br>Line \\| two | actual outcome 'reject' != expected 'accept' |"
+    ) in markdown
+
+
+def test_render_markdown_handles_missing_summary_tool_response() -> None:
+    markdown = render_markdown(
+        {
+            "base_url": "http://testserver",
+            "total": 1,
+            "passed": 1,
+            "failed": 0,
+            "stats": {
+                "overall": {
+                    "total": 1,
+                    "classified": 1,
+                    "accuracy": 1.0,
+                    "false_positives": 0,
+                    "false_negatives": 0,
+                    "unknown": 0,
+                },
+                "by_country": {},
+            },
+            "results": [
+                {
+                    "case": "example/real/case_001",
+                    "passed": True,
+                    "expected_outcome": "accept",
+                    "actual_outcome": "accept",
+                    "classification": "TP",
+                    "final_response": "Accepted.",
+                    "errors": [],
+                }
+            ],
+        }
+    )
+
+    assert "| `example/real/case_001` | PASS | accept | accept | TP | 9 |  |  |" in markdown

--- a/tests/unit/test_e2e_runner_summary.py
+++ b/tests/unit/test_e2e_runner_summary.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from e2e import runner
+from e2e.cases import Case
+
+
+def test_run_case_adds_summary_tool_response_without_replacing_tool_summary(monkeypatch, tmp_path: Path) -> None:
+    case = Case(
+        country="example",
+        kind="real",
+        case_id="case_001",
+        path=tmp_path / "case_001",
+        narrative="Please verify this certificate.",
+        certificate_path=None,
+        expected={"expected_outcome": "accept"},
+    )
+    captured = {}
+    tool_result = {
+        "tool": "death_certificate_verification",
+        "accepted": True,
+        "summary": "Original verification summary.",
+    }
+
+    def fake_post_turn(client, base_url, payload, headers, label):
+        return {
+            "label": label,
+            "status_code": 200,
+            "latency_seconds": 0.1,
+            "response_json": {
+                "response": "verification passed",
+                "debug": {"tool_results": [tool_result]},
+            },
+            "response_text": "verification passed",
+        }
+
+    def fake_summarize(result):
+        captured["result"] = dict(result)
+        return "summary from summary tool"
+
+    monkeypatch.setattr(runner, "post_turn", fake_post_turn)
+    monkeypatch.setattr(runner, "summarize_case_result", fake_summarize)
+
+    result = runner.run_case(
+        object(),
+        case,
+        base_url="http://testserver",
+        secret="",
+        local_mode=True,
+        debug_tools=False,
+    )
+
+    assert result["passed"] is True
+    assert result["classification"] == "TP"
+    assert result["tool_result"]["summary"] == "Original verification summary."
+    assert result["summary_tool_response"] == "summary from summary tool"
+    assert result["final_response"] == "verification passed"
+    assert captured["result"]["tool_result"]["summary"] == "Original verification summary."
+    assert "summary_tool_response" not in captured["result"]

--- a/tests/unit/test_e2e_summary_tool.py
+++ b/tests/unit/test_e2e_summary_tool.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+from pydantic_ai.messages import ModelRequest, ModelResponse
+
+from e2e import summary_tool
+from tools.summary.summary import ConversationSummaryTool
+
+
+def test_build_summary_messages_keeps_existing_tool_summary_context() -> None:
+    result = {
+        "case": "example/real/case_001",
+        "country": "example",
+        "kind": "real",
+        "case_id": "case_001",
+        "expected_outcome": "accept",
+        "actual_outcome": "reject",
+        "classification": "FN",
+        "verdict_source": "tool_result",
+        "passed": False,
+        "errors": ["actual outcome 'reject' != expected 'accept'"],
+        "tool_result": {
+            "accepted": False,
+            "summary": "Original death certificate verification summary.",
+        },
+        "turns": [
+            {
+                "label": "media",
+                "status_code": 200,
+                "latency_seconds": 1.25,
+                "response_json": {"response": "The certificate was rejected."},
+            }
+        ],
+        "final_response": "The certificate was rejected.",
+    }
+
+    messages = summary_tool.build_summary_messages(result)
+
+    assert len(messages) == 2
+    assert isinstance(messages[0], ModelRequest)
+    assert isinstance(messages[1], ModelResponse)
+    request_content = messages[0].parts[0].content
+    response_content = messages[1].parts[0].content
+    assert "example/real/case_001" in request_content
+    assert '"classification": "FN"' in request_content
+    assert '"summary": "Original death certificate verification summary."' in request_content
+    assert response_content == "The certificate was rejected."
+
+
+def test_summarize_case_result_returns_summary_tool_response(monkeypatch) -> None:
+    seen = {}
+
+    async def fake_call(messages):
+        seen["messages"] = messages
+        return "case summary"
+
+    monkeypatch.setattr(summary_tool, "call_summary_tool", fake_call)
+
+    result = {
+        "case": "example/real/case_001",
+        "final_response": "accepted",
+    }
+
+    assert summary_tool.summarize_case_result(result) == "case summary"
+    assert seen["messages"][1].parts[0].content == "accepted"
+
+
+def test_summarize_case_result_records_summary_tool_errors(monkeypatch) -> None:
+    async def fake_call(messages):
+        raise ValueError("boom")
+
+    monkeypatch.setattr(summary_tool, "call_summary_tool", fake_call)
+
+    response = summary_tool.summarize_case_result({"case": "example/real/case_001"})
+
+    assert response == "summary_tool_error: ValueError: boom"
+
+
+def test_summary_tool_messages_support_conversation_summary_transcript_builder() -> None:
+    messages = summary_tool.build_summary_messages(
+        {
+            "case": "example/real/case_001",
+            "classification": "TP",
+            "final_response": "verification passed",
+        }
+    )
+
+    transcript = ConversationSummaryTool._build_transcript(
+        object(),
+        summary_tool.summary_tool_messages(messages),
+    )
+
+    assert "example/real/case_001" in transcript
+    assert "verification passed" in transcript

--- a/tests/unit/test_summary_response.py
+++ b/tests/unit/test_summary_response.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from src import summary_response
+
+
+def test_summary_payload_uses_verification_summary_without_tool_framing() -> None:
+    payload = summary_response.summary_payload(
+        "The request was accepted.",
+        [
+            {
+                "tool": "death_certificate_verification",
+                "accepted": True,
+                "handed_off": True,
+                "summary": "Verification passed.",
+                "flags": [],
+            }
+        ],
+    )
+
+    assert payload == {
+        "assistant_response": "The request was accepted.",
+        "death_certificate_verification": {
+            "status": None,
+            "accepted": True,
+            "handed_off": True,
+            "summary": "Verification passed.",
+            "flags": [],
+        },
+    }
+
+
+def test_summary_prompt_excludes_internal_e2e_language() -> None:
+    prompt = summary_response.summary_prompt(
+        "The request was accepted.",
+        [
+            {
+                "tool": "death_certificate_verification",
+                "accepted": True,
+                "summary": "Verification passed.",
+                "flags": [],
+            }
+        ],
+    )
+
+    assert "WhatsApp-ready" in prompt
+    assert "Do not mention internal tools" in prompt
+    assert "e2e test case result" not in prompt
+    assert "debug output" in prompt
+
+
+def test_generate_summary_tool_response_returns_none_on_error(monkeypatch) -> None:
+    async def fake_call(messages):
+        raise RuntimeError("model unavailable")
+
+    monkeypatch.setattr(summary_response, "call_summary_tool", fake_call)
+
+    result = summary_response.generate_summary_tool_response(
+        final_response="The request was accepted.",
+        tool_events=[],
+    )
+
+    import asyncio
+
+    assert asyncio.run(result) is None

--- a/tests/unit/test_whatsapp_outbound.py
+++ b/tests/unit/test_whatsapp_outbound.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import httpx
+
+from src import whatsapp_outbound
+
+
+async def test_send_text_message_posts_to_graph_api(monkeypatch) -> None:
+    captured = {}
+
+    class FakeResponse:
+        def raise_for_status(self) -> None:
+            return None
+
+    class FakeClient:
+        def __init__(self, *, timeout):
+            captured["timeout"] = timeout
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return None
+
+        async def post(self, url, *, json, headers):
+            captured["url"] = url
+            captured["json"] = json
+            captured["headers"] = headers
+            return FakeResponse()
+
+    monkeypatch.delenv("E2E_DISABLE_WHATSAPP_OUTBOUND", raising=False)
+    monkeypatch.setenv("WHATSAPP_TOKEN", "token-123")
+    monkeypatch.setenv("WHATSAPP_GRAPH_VERSION", "v99.0")
+    monkeypatch.setattr(whatsapp_outbound.httpx, "AsyncClient", FakeClient)
+
+    sent = await whatsapp_outbound.send_text_message(
+        wa_id="16508106640",
+        phone_number_id="1104821716055506",
+        text="Verification summary.",
+    )
+
+    assert sent is True
+    assert captured["url"] == "https://graph.facebook.com/v99.0/1104821716055506/messages"
+    assert captured["headers"]["Authorization"] == "Bearer token-123"
+    assert captured["json"] == {
+        "messaging_product": "whatsapp",
+        "to": "16508106640",
+        "type": "text",
+        "text": {"body": "Verification summary."},
+    }
+
+
+async def test_send_text_message_skips_when_disabled(monkeypatch) -> None:
+    monkeypatch.setenv("E2E_DISABLE_WHATSAPP_OUTBOUND", "1")
+    monkeypatch.setenv("WHATSAPP_TOKEN", "token-123")
+
+    sent = await whatsapp_outbound.send_text_message(
+        wa_id="16508106640",
+        phone_number_id="1104821716055506",
+        text="Verification summary.",
+    )
+
+    assert sent is False
+
+
+async def test_send_text_message_skips_missing_configuration(monkeypatch) -> None:
+    monkeypatch.delenv("E2E_DISABLE_WHATSAPP_OUTBOUND", raising=False)
+    monkeypatch.delenv("WHATSAPP_TOKEN", raising=False)
+    monkeypatch.delenv("WHATSAPP_PHONE_NUMBER_ID", raising=False)
+
+    assert await whatsapp_outbound.send_text_message(wa_id="16508106640", text="x") is False
+
+
+async def test_send_text_message_returns_false_on_http_error(monkeypatch) -> None:
+    class FakeResponse:
+        def raise_for_status(self) -> None:
+            raise httpx.HTTPStatusError(
+                "bad",
+                request=httpx.Request("POST", "http://test"),
+                response=httpx.Response(500),
+            )
+
+    class FakeClient:
+        def __init__(self, *, timeout):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return None
+
+        async def post(self, url, *, json, headers):
+            return FakeResponse()
+
+    monkeypatch.delenv("E2E_DISABLE_WHATSAPP_OUTBOUND", raising=False)
+    monkeypatch.setenv("WHATSAPP_TOKEN", "token-123")
+    monkeypatch.setattr(whatsapp_outbound.httpx, "AsyncClient", FakeClient)
+
+    sent = await whatsapp_outbound.send_text_message(
+        wa_id="16508106640",
+        phone_number_id="1104821716055506",
+        text="Verification summary.",
+    )
+
+    assert sent is False


### PR DESCRIPTION
## Summary
- Generate and store per-case summary_tool_response values in e2e results.json
- Add Summary Tool Response to e2e Markdown reports
- Send generated summaries as a second outbound WhatsApp message in production while keeping the original webhook response unchanged
- Disable outbound WhatsApp sends during local e2e runs
- Add unit coverage for summary generation, report rendering, API hooks, and outbound sends

## Tests
- .venv-testplan/bin/python -m pytest -q tests/unit/test_api.py tests/unit/test_whatsapp_outbound.py tests/unit/test_summary_response.py tests/unit/test_e2e_reports.py tests/unit/test_e2e_summary_tool.py tests/unit/test_e2e_runner_summary.py