### PR TITLE
Add GiveLight Drive handoff automation

### DIFF
--- a/docs/integrations/google-drive-handoff.md
+++ b/docs/integrations/google-drive-handoff.md
@@ -2,7 +2,9 @@
 
 Accepted death-certificate cases are uploaded to GiveLight as two files with a
 shared filename stem: the JSON verification payload and the original image (or
-PDF). The destination should be a folder in a Google Shared Drive.
+PDF). The stem is an opaque `death-certificate-<uuid>` identifier and does not
+contain a contact-derived value or submission timestamp. The destination should
+be a folder in a Google Shared Drive.
 
 ## Google Cloud and GiveLight setup
 
@@ -20,6 +22,30 @@ PDF). The destination should be a folder in a Google Shared Drive.
 The uploader requests only the
 `https://www.googleapis.com/auth/drive.file` OAuth scope. Store configuration in
 the deployment platform; never commit credentials or secret values.
+
+## Optional GiveLight private-folder automation
+
+If B2 should upload only to a shared staging folder, GiveLight can own a
+standalone Apps Script that copies complete JSON/document pairs into a private
+GiveLight folder and then sends a notification email. This keeps the private
+folder and email authority under GiveLight's Google account; the B2 service
+account needs access only to the staging folder.
+
+See the
+[`integrations/givelight-drive-automation`](../../integrations/givelight-drive-automation/README.md)
+setup guide and reference implementation. The automation polls once per minute,
+validates and processes batches of up to 10 pairs, copies both files before
+sending email, and trashes the staging copies only after notification succeeds.
+Resumable Script Properties prevent ordinary retries from repeating completed
+steps, though an interruption between an external Drive or email operation and
+its state write can still cause a duplicate.
+
+Run the script as a dedicated GiveLight automation account with access only to
+the staging and destination folders. Restrict staging writers to the B2 runtime
+service account and designated GiveLight administrators, and grant the
+automation account permission to trash staging files. Filename, size, and JSON
+schema checks do not provide cryptographic provenance; the reference workflow
+does not implement a signed manifest or HMAC.
 
 ## WhatsApp configuration
 

--- a/integrations/givelight-drive-automation/Code.gs
+++ b/integrations/givelight-drive-automation/Code.gs
@@ -1,0 +1,415 @@
+const DOCUMENT_EXTENSIONS = [
+  "jpg",
+  "jpeg",
+  "png",
+  "webp",
+  "heic",
+  "heif",
+  "pdf",
+  "bin",
+];
+const HANDOFF_STEM_PREFIX = "death-certificate-";
+const HANDOFF_STATE_PREFIX = "HANDOFF_STATE_";
+const MAX_HANDOFFS_PER_RUN = 10;
+const MAX_JSON_BYTES = 1024 * 1024;
+const MAX_DOCUMENT_BYTES = 20 * 1024 * 1024;
+
+/**
+ * Copies complete handoff pairs into GiveLight's private folder, sends a
+ * notification, and then removes the staging copies.
+ */
+function processHandoffs() {
+  const lock = LockService.getScriptLock();
+  if (!lock.tryLock(0)) {
+    return;
+  }
+
+  try {
+    const properties = PropertiesService.getScriptProperties();
+    const stagingFolderId = getRequiredProperty_(properties, "STAGING_FOLDER_ID");
+    const destinationFolderId = getRequiredProperty_(
+      properties,
+      "DESTINATION_FOLDER_ID",
+    );
+    const notificationEmails = getRequiredProperty_(
+      properties,
+      "NOTIFICATION_EMAILS",
+    );
+    const notificationSubject =
+      properties.getProperty("NOTIFICATION_SUBJECT") ||
+      "GiveLight Drive handoff completed";
+    assertFolderAccessible_(stagingFolderId);
+    assertFolderAccessible_(destinationFolderId);
+    const config = {
+      destinationFolderId: destinationFolderId,
+      notificationEmails: notificationEmails,
+      notificationSubject: notificationSubject,
+      properties: properties,
+    };
+
+    const pendingStates = loadPendingStates_(properties);
+    const knownJsonIds = {};
+    pendingStates.forEach(function (state) {
+      knownJsonIds[state.sourceJsonId] = true;
+    });
+
+    const pendingLimit = Math.floor(MAX_HANDOFFS_PER_RUN / 2);
+    const pendingToAttempt = pendingStates.slice(0, pendingLimit);
+    pendingToAttempt.forEach(function (state) {
+      processStateSafely_(state, config);
+    });
+
+    const available = MAX_HANDOFFS_PER_RUN - pendingToAttempt.length;
+    findCompleteHandoffs_(stagingFolderId, knownJsonIds)
+      .slice(0, available)
+      .forEach(function (handoff) {
+        const state = createState_(handoff);
+        try {
+          saveState_(properties, state);
+        } catch (error) {
+          console.error("A new handoff's retry state could not be saved.");
+          return;
+        }
+        processStateSafely_(state, config);
+      });
+  } finally {
+    lock.releaseLock();
+  }
+}
+
+/**
+ * Replaces this project's existing processHandoffs triggers with a trigger
+ * that checks for completed handoffs every minute.
+ */
+function installTrigger() {
+  ScriptApp.getProjectTriggers().forEach(function (trigger) {
+    if (trigger.getHandlerFunction() === "processHandoffs") {
+      ScriptApp.deleteTrigger(trigger);
+    }
+  });
+
+  ScriptApp.newTrigger("processHandoffs").timeBased().everyMinutes(1).create();
+}
+
+function processStateSafely_(state, config) {
+  try {
+    processState_(state, config);
+  } catch (error) {
+    state.lastAttemptAt = new Date().toISOString();
+    try {
+      saveState_(config.properties, state);
+    } catch (stateError) {
+      console.error("A failed handoff's retry state could not be saved.");
+    }
+    console.error("A pending handoff could not be resumed; it will be retried.");
+  }
+}
+
+function processState_(state, config) {
+  if (!state.validated) {
+    const sourceJson = getFileMetadata_(state.sourceJsonId);
+    const sourceDocument = getFileMetadata_(state.sourceDocumentId);
+    validateState_(state, sourceJson, sourceDocument);
+    state.validated = true;
+    saveState_(config.properties, state);
+  }
+
+  if (!state.destinationJsonCopyId) {
+    const sourceJson = getFileMetadata_(state.sourceJsonId);
+    const jsonCopy = Drive.Files.copy(
+      {
+        name: sourceJson.name,
+        parents: [config.destinationFolderId],
+      },
+      sourceJson.id,
+      { supportsAllDrives: true, fields: "id" },
+    );
+    state.destinationJsonCopyId = jsonCopy.id;
+    saveState_(config.properties, state);
+  }
+
+  if (!state.destinationDocumentCopyId) {
+    const sourceDocument = getFileMetadata_(state.sourceDocumentId);
+    const documentCopy = Drive.Files.copy(
+      {
+        name: sourceDocument.name,
+        parents: [config.destinationFolderId],
+      },
+      sourceDocument.id,
+      { supportsAllDrives: true, fields: "id" },
+    );
+    state.destinationDocumentCopyId = documentCopy.id;
+    saveState_(config.properties, state);
+  }
+
+  if (!state.notificationSent) {
+    sendNotification_(config);
+    state.notificationSent = true;
+    saveState_(config.properties, state);
+  }
+
+  if (!state.sourceJsonTrashed) {
+    trashFile_(state.sourceJsonId);
+    state.sourceJsonTrashed = true;
+    saveState_(config.properties, state);
+  }
+
+  if (!state.sourceDocumentTrashed) {
+    trashFile_(state.sourceDocumentId);
+    state.sourceDocumentTrashed = true;
+    saveState_(config.properties, state);
+  }
+
+  config.properties.deleteProperty(stateKey_(state.sourceJsonId));
+}
+
+function sendNotification_(config) {
+  const timestamp = Utilities.formatDate(
+    new Date(),
+    Session.getScriptTimeZone(),
+    "yyyy-MM-dd HH:mm:ss z",
+  );
+  const destinationFolderUrl =
+    "https://drive.google.com/drive/folders/" + config.destinationFolderId;
+
+  MailApp.sendEmail({
+    to: config.notificationEmails,
+    subject: config.notificationSubject,
+    body: [
+      "A GiveLight Drive handoff completed.",
+      "",
+      "Timestamp: " + timestamp,
+      "Files copied: 2 (verification JSON and source document)",
+      "Destination folder: " + destinationFolderUrl,
+    ].join("\n"),
+  });
+}
+
+function createState_(handoff) {
+  return {
+    stem: handoff.stem,
+    sourceJsonId: handoff.jsonFile.id,
+    sourceDocumentId: handoff.documentFile.id,
+    validated: false,
+    destinationJsonCopyId: null,
+    destinationDocumentCopyId: null,
+    notificationSent: false,
+    sourceJsonTrashed: false,
+    sourceDocumentTrashed: false,
+    lastAttemptAt: null,
+  };
+}
+
+function loadPendingStates_(properties) {
+  const allProperties = properties.getProperties();
+  const states = [];
+  Object.keys(allProperties)
+    .filter(function (key) {
+      return key.indexOf(HANDOFF_STATE_PREFIX) === 0;
+    })
+    .sort()
+    .forEach(function (key) {
+      try {
+        const state = JSON.parse(allProperties[key]);
+        if (
+          !state ||
+          !state.stem ||
+          !state.sourceJsonId ||
+          !state.sourceDocumentId ||
+          typeof state.validated !== "boolean" ||
+          key !== stateKey_(state.sourceJsonId)
+        ) {
+          throw new Error("Invalid handoff state.");
+        }
+        states.push(state);
+      } catch (error) {
+        console.error("A saved handoff state is invalid and was skipped.");
+      }
+    });
+  return states.sort(function (left, right) {
+    if (!left.lastAttemptAt && right.lastAttemptAt) {
+      return -1;
+    }
+    if (left.lastAttemptAt && !right.lastAttemptAt) {
+      return 1;
+    }
+    return String(left.lastAttemptAt || "").localeCompare(
+      String(right.lastAttemptAt || ""),
+    );
+  });
+}
+
+function saveState_(properties, state) {
+  properties.setProperty(
+    stateKey_(state.sourceJsonId),
+    JSON.stringify(state),
+  );
+}
+
+function stateKey_(sourceJsonId) {
+  return HANDOFF_STATE_PREFIX + sourceJsonId;
+}
+
+function validateState_(state, jsonFile, documentFile) {
+  const jsonName = splitFileName_(jsonFile.name);
+  const documentName = splitFileName_(documentFile.name);
+  if (
+    state.stem.indexOf(HANDOFF_STEM_PREFIX) !== 0 ||
+    jsonName.stem !== state.stem ||
+    documentName.stem !== state.stem ||
+    jsonName.extension !== "json" ||
+    DOCUMENT_EXTENSIONS.indexOf(documentName.extension) === -1
+  ) {
+    throw new Error("Unexpected handoff filename.");
+  }
+  if (Number(jsonFile.size) > MAX_JSON_BYTES) {
+    throw new Error("Verification JSON is too large.");
+  }
+  if (Number(documentFile.size) > MAX_DOCUMENT_BYTES) {
+    throw new Error("Source document is too large.");
+  }
+
+  const payload = JSON.parse(downloadFileText_(jsonFile.id));
+  if (
+    !payload ||
+    typeof payload.schema_version !== "string" ||
+    !payload.schema_version.trim() ||
+    typeof payload.submitted_at !== "string" ||
+    !payload.submitted_at.trim()
+  ) {
+    throw new Error("Verification JSON is missing required fields.");
+  }
+}
+
+function splitFileName_(name) {
+  const extensionMatch = name.match(/\.([^.]+)$/);
+  if (!extensionMatch) {
+    return { stem: name, extension: "" };
+  }
+  return {
+    stem: name.slice(0, -extensionMatch[0].length),
+    extension: extensionMatch[1].toLowerCase(),
+  };
+}
+
+function findCompleteHandoffs_(folderId, excludedJsonIds) {
+  const jsonFilesByStem = {};
+  const documentFilesByStem = {};
+  const files = listFilesInFolder_(folderId);
+
+  files.forEach(function (file) {
+    const name = file.name;
+    const extensionMatch = name.match(/\.([^.]+)$/);
+
+    if (!extensionMatch) {
+      return;
+    }
+
+    const extension = extensionMatch[1].toLowerCase();
+    const stem = name.slice(0, -extensionMatch[0].length);
+    if (stem.indexOf(HANDOFF_STEM_PREFIX) !== 0) {
+      return;
+    }
+
+    if (extension === "json") {
+      addFileByStem_(jsonFilesByStem, stem, file);
+    } else if (DOCUMENT_EXTENSIONS.indexOf(extension) !== -1) {
+      addFileByStem_(documentFilesByStem, stem, file);
+    }
+  });
+
+  return Object.keys(jsonFilesByStem)
+    .filter(function (stem) {
+      return (
+        jsonFilesByStem[stem].length === 1 &&
+        !excludedJsonIds[jsonFilesByStem[stem][0].id] &&
+        documentFilesByStem[stem] &&
+        documentFilesByStem[stem].length === 1
+      );
+    })
+    .sort()
+    .map(function (stem) {
+      return {
+        stem: stem,
+        jsonFile: jsonFilesByStem[stem][0],
+        documentFile: documentFilesByStem[stem][0],
+      };
+    });
+}
+
+function listFilesInFolder_(folderId) {
+  const files = [];
+  let pageToken;
+
+  do {
+    const options = {
+      q: "'" + folderId + "' in parents and trashed = false",
+      spaces: "drive",
+      supportsAllDrives: true,
+      includeItemsFromAllDrives: true,
+      fields: "nextPageToken,files(id,name,size)",
+    };
+    if (pageToken) {
+      options.pageToken = pageToken;
+    }
+
+    const response = Drive.Files.list(options);
+    Array.prototype.push.apply(files, response.files || []);
+    pageToken = response.nextPageToken;
+  } while (pageToken);
+
+  return files;
+}
+
+function getFileMetadata_(fileId) {
+  return Drive.Files.get(fileId, {
+    supportsAllDrives: true,
+    fields: "id,name,size",
+  });
+}
+
+function assertFolderAccessible_(folderId) {
+  const folder = Drive.Files.get(folderId, {
+    supportsAllDrives: true,
+    fields: "id,mimeType",
+  });
+  if (folder.mimeType !== "application/vnd.google-apps.folder") {
+    throw new Error("Configured Drive ID is not a folder.");
+  }
+}
+
+function downloadFileText_(fileId) {
+  const url =
+    "https://www.googleapis.com/drive/v3/files/" +
+    encodeURIComponent(fileId) +
+    "?alt=media&supportsAllDrives=true";
+  return UrlFetchApp.fetch(url, {
+    headers: {
+      Authorization: "Bearer " + ScriptApp.getOAuthToken(),
+    },
+  }).getContentText("UTF-8");
+}
+
+function trashFile_(fileId) {
+  Drive.Files.update(
+    { trashed: true },
+    fileId,
+    null,
+    { supportsAllDrives: true, fields: "id,trashed" },
+  );
+}
+
+function addFileByStem_(filesByStem, stem, file) {
+  if (!filesByStem[stem]) {
+    filesByStem[stem] = [];
+  }
+  filesByStem[stem].push(file);
+}
+
+function getRequiredProperty_(properties, name) {
+  const value = properties.getProperty(name);
+  if (!value || !value.trim()) {
+    throw new Error("Missing required Script Property: " + name);
+  }
+  return value.trim();
+}

--- a/integrations/givelight-drive-automation/README.md
+++ b/integrations/givelight-drive-automation/README.md
@@ -1,0 +1,120 @@
+# GiveLight Drive automation
+
+This standalone Google Apps Script lets GiveLight move completed handoffs across
+an access boundary without granting B2 access to GiveLight's private Drive
+folder. The B2 service uploads a JSON file and its matching document to a shared
+staging folder. A GiveLight-owned script checks that folder every minute, copies
+complete pairs into a private destination folder, and emails a notification.
+
+Use a dedicated GiveLight automation account to create and authorize the
+script. That account must have access only to the staging and destination
+folders needed by this workflow. It must be able to read and trash files in the
+staging folder and create files in the private destination folder. Restrict
+staging-folder writers to the B2 runtime service account and designated
+GiveLight administrators. Notification emails are sent as the authorizing
+GiveLight account. Apps Script email and runtime quotas apply, and a handoff may
+take up to approximately one minute to process.
+
+## Create the Apps Script project
+
+1. Sign in to the dedicated GiveLight automation account that will own the
+   automation.
+2. Go to [script.google.com](https://script.google.com/) and select **New
+   project**.
+3. Give the project a recognizable name, such as `GiveLight Drive Handoff`.
+4. Replace the contents of `Code.gs` with this directory's
+   [`Code.gs`](./Code.gs).
+5. Open **Project Settings**, enable **Show "appsscript.json" manifest file in
+   editor**, and replace that file's contents with this directory's
+   [`appsscript.json`](./appsscript.json).
+
+The manifest enables the Advanced Drive service v3 used for both My Drive and
+Shared Drive folders. If the script is linked to a standard Google Cloud
+project instead of its default Apps Script Cloud project, also enable the
+Google Drive API in that standard project.
+
+## Configure Script Properties
+
+In **Project Settings**, under **Script Properties**, add:
+
+- `STAGING_FOLDER_ID`: the ID of the folder shared with the B2 service account.
+- `DESTINATION_FOLDER_ID`: the ID of GiveLight's private destination folder.
+- `NOTIFICATION_EMAILS`: one or more comma-separated notification recipients.
+- `NOTIFICATION_SUBJECT` (optional): the email subject. It defaults to
+  `GiveLight Drive handoff completed`.
+
+A folder ID is the value after `/folders/` in a Google Drive folder URL. Do not
+put credentials or document data in Script Properties.
+
+## Authorize and install the trigger
+
+1. In the Apps Script editor, select `installTrigger` from the function menu.
+2. Click **Run**.
+3. Review and approve the requested Drive, external-request, email, and trigger
+   permissions for the GiveLight account. The external request is used only to
+   download the verification JSON from the Google Drive API for validation.
+4. Open **Triggers** in the left sidebar and confirm that `processHandoffs` has
+   a time-driven trigger that runs every minute.
+
+Running `installTrigger` again replaces any existing `processHandoffs` triggers
+in this project, so it is safe to use when repairing the schedule.
+
+## Test the automation
+
+1. Put two test files in the staging folder with the same filename stem, for
+   example `death-certificate-1234.json` and `death-certificate-1234.pdf`. The
+   JSON must be valid UTF-8 JSON with nonempty `schema_version` and
+   `submitted_at` string fields. Supported document extensions are `.jpg`,
+   `.jpeg`, `.png`, `.webp`, `.heic`, `.heif`, `.pdf`, and `.bin`, matched
+   case-insensitively.
+2. Select `processHandoffs` in the Apps Script editor and click **Run**, or wait
+   for the scheduled trigger.
+3. Confirm that both files appear in the destination folder, the configured
+   recipients receive an email, and the staging copies move to trash.
+
+Incomplete pairs remain in staging for a later run. A candidate must have a
+`death-certificate-` filename stem, exactly one JSON file and one supported
+document, JSON no larger than 1 MiB, and a document no larger than 20 MiB. The
+script parses the JSON only to check the two required fields; it does not log or
+email its contents. These checks reduce accidental or malformed input, but they
+do not cryptographically prove that B2 created the files. This version does not
+use a signed manifest or HMAC, so staging write access must remain restricted.
+
+The script processes at most 10 handoffs per invocation. Failures are isolated
+per handoff so one bad pair does not prevent later pairs from running. Script
+Properties record the source IDs, destination copy IDs, notification status,
+and cleanup status after each completed step. A later run resumes pending work
+before discovering new pairs, avoids repeating steps already recorded as
+complete, and can finish cleanup even after source files leave the staging
+folder. When pending work exists, each run attempts at most five pending
+handoffs so at least half of the batch remains available for newly discovered
+work. Failed pending handoffs record only a retry timestamp and are rotated
+oldest-first on later runs, preventing one persistent failure from monopolizing
+the retry capacity. Complete pairs enter this isolated state before validation,
+so malformed pairs also rotate instead of repeatedly occupying new-work slots.
+A permanently invalid pair remains pending until an administrator fixes its
+source files or removes its `HANDOFF_STATE_...` Script Property and the invalid
+staging files.
+
+The operation order is copy both files, send the email, then trash both staging
+files. The state is removed only after both source files are trashed. The
+automation account therefore requires permission to trash staging files. As
+with any external call followed by a state write, there is a small crash window
+after `MailApp` accepts an email but before `notificationSent` is saved; an
+interruption in that window can produce a duplicate notification. Similar
+interruptions immediately after a Drive copy can produce a duplicate copy, so
+the workflow does not claim perfect exactly-once processing.
+
+The notification contains only the processing timestamp, a statement that the
+verification JSON and source document were copied, and the destination folder
+link. It does not include filenames, JSON contents, extracted fields, or the
+source document as an attachment. B2 generates opaque UUID-based filenames so
+folder metadata does not expose contact-derived identifiers or submission
+timestamps.
+
+## Disable or remove the automation
+
+Open **Triggers** in the Apps Script project's left sidebar, locate the
+`processHandoffs` trigger, open its actions menu, and select **Delete trigger**.
+Deleting the Apps Script project also removes its triggers. Removing the trigger
+does not change files that have already been copied or trashed.

--- a/integrations/givelight-drive-automation/appsscript.json
+++ b/integrations/givelight-drive-automation/appsscript.json
@@ -1,0 +1,19 @@
+{
+  "timeZone": "America/Los_Angeles",
+  "runtimeVersion": "V8",
+  "dependencies": {
+    "enabledAdvancedServices": [
+      {
+        "userSymbol": "Drive",
+        "serviceId": "drive",
+        "version": "v3"
+      }
+    ]
+  },
+  "oauthScopes": [
+    "https://www.googleapis.com/auth/drive",
+    "https://www.googleapis.com/auth/script.external_request",
+    "https://www.googleapis.com/auth/script.send_mail",
+    "https://www.googleapis.com/auth/script.scriptapp"
+  ]
+}

--- a/tests/unit/tools/death_certificate_pipeline/test_handoff.py
+++ b/tests/unit/tools/death_certificate_pipeline/test_handoff.py
@@ -15,6 +15,11 @@ async def test_uploads_json_and_original_image(monkeypatch):
     monkeypatch.setenv("GOOGLE_DRIVE_FOLDER_ID", "give-light-folder")
 
     monkeypatch.setattr(handoff, "_get_access_token", lambda: "drive-token")
+    monkeypatch.setattr(
+        handoff,
+        "uuid4",
+        lambda: "12345678-1234-5678-1234-567812345678",
+    )
 
     requests = []
 
@@ -59,6 +64,12 @@ async def test_uploads_json_and_original_image(monkeypatch):
         contents.append(remainder.split(b"\r\n\r\n", 1)[1].rsplit(b"\r\n--", 1)[0])
 
     json_name, image_name = metadata[0]["name"], metadata[1]["name"]
+    assert json_name == "death-certificate-12345678-1234-5678-1234-567812345678.json"
+    assert image_name == "death-certificate-12345678-1234-5678-1234-567812345678.jpg"
+    assert "aaaaaaaaaaaaaaaa" not in json_name
+    assert "aaaaaaaaaaaaaaaa" not in image_name
+    assert "2026-08-07" not in json_name
+    assert "2026-08-07" not in image_name
     assert json_name.removesuffix(".json") == image_name.removesuffix(".jpg")
     assert metadata[0]["parents"] == metadata[1]["parents"] == ["give-light-folder"]
     assert metadata[0]["mimeType"] == "application/json"

--- a/tools/death_certificate_pipeline/handoff.py
+++ b/tools/death_certificate_pipeline/handoff.py
@@ -7,6 +7,7 @@ import json
 import os
 from datetime import datetime, timezone
 from typing import Any
+from uuid import uuid4
 
 import httpx
 
@@ -107,9 +108,7 @@ async def deliver_to_gl(
     try:
         token = await asyncio.to_thread(_get_access_token)
 
-        contact = str(payload.get("contact_identifier") or "unlinked")[:16]
-        submitted_at = str(payload.get("submitted_at") or "").replace(":", "-")
-        stem = f"death-certificate-{contact}-{submitted_at}"
+        stem = f"death-certificate-{uuid4()}"
         extension = _IMAGE_EXTENSIONS.get(image_mime_type, ".bin")
         upload_mime_type = (
             image_mime_type if image_mime_type in _IMAGE_EXTENSIONS else "application/octet-stream"


### PR DESCRIPTION
## Summary

- Add a GiveLight-owned Apps Script for transferring completed death-certificate handoffs from a shared staging folder into GiveLight’s private Drive folder.
- Support both My Drive and Shared Drives through Drive API v3.
- Send a privacy-safe email notification after each successful handoff.
- Replace contact-derived filenames with opaque UUID-based identifiers.
- Add setup, permissions, testing, and deployment documentation.

## Handoff flow

1. B2 uploads a matching JSON and source-document pair to the staging folder.
2. The Apps Script checks the staging folder every minute.
3. It validates the filenames, file sizes, and required JSON fields.
4. It copies both files into GiveLight’s private destination folder.
5. It sends an email notification without certificate data, filenames, or attachments.
6. It moves the staging copies to trash.
7. If a step fails, saved state allows the next run to resume without repeating completed steps.

## Testing

- Focused tests: `8 passed`
- JavaScript syntax, manifest JSON, and whitespace checks passed
- Manual Drive test verified copying, retry recovery, and staging cleanup